### PR TITLE
fix(ci): enable EPEL for ccache on Rocky 10

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Install build dependencies
         if: steps.filter.outputs.skip != 'true'
         run: |
+          dnf install -y epel-release
+          dnf config-manager --set-enabled crb
           dnf install -y \
             gcc make elfutils-libelf-devel openssl-devel openssl \
             bc bison flex rsync rpm-build dwarves kmod \


### PR DESCRIPTION
ccache isn't in Rocky 10 base repos. Enable EPEL + CRB before dnf install.