### PR TITLE
Own carried patches and add a Pages install surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/cadence.yml
+++ b/.github/ISSUE_TEMPLATE/cadence.yml
@@ -1,0 +1,27 @@
+name: Cadence Work
+description: Track weekly upstream merge or release-cadence work.
+title: "cadence: "
+labels:
+  - cadence
+body:
+  - type: input
+    id: kernel_version
+    attributes:
+      label: Target Kernel Version
+      placeholder: 6.15.x or 6.12.y
+    validations:
+      required: true
+  - type: textarea
+    id: divergence
+    attributes:
+      label: Divergence Summary
+      description: What changed upstream and what still needs to be carried?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What has to be true to ship this cadence item?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Install Docs
+    url: https://tinyland-inc.github.io/linux-xr/
+    about: Use the stable install and rollout docs before filing deployment issues.

--- a/.github/ISSUE_TEMPLATE/deployment.yml
+++ b/.github/ISSUE_TEMPLATE/deployment.yml
@@ -1,0 +1,33 @@
+name: Deployment
+description: Track host rollout or install-surface work.
+title: "deployment: "
+labels:
+  - deployment
+body:
+  - type: input
+    id: host
+    attributes:
+      label: Host
+      placeholder: honey or yoga
+    validations:
+      required: true
+  - type: input
+    id: current_kernel
+    attributes:
+      label: Current Kernel
+      placeholder: 6.12.0-124.45.1.el10_1.x86_64
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Target Variant
+      options:
+        - generic
+        - rt
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/upstream.yml
+++ b/.github/ISSUE_TEMPLATE/upstream.yml
@@ -1,0 +1,27 @@
+name: Upstream Opportunity
+description: Track a carry patch that should be reduced, dropped, or submitted upstream.
+title: "upstream: "
+labels:
+  - upstream
+body:
+  - type: input
+    id: patch
+    attributes:
+      label: Carry Patch
+      placeholder: xr/patches/bigscreen-beyond-edid.patch
+    validations:
+      required: true
+  - type: textarea
+    id: current_state
+    attributes:
+      label: Current State
+      description: Link the current thread, series, or upstream source.
+    validations:
+      required: true
+  - type: textarea
+    id: next_step
+    attributes:
+      label: Next Step
+      description: resend, rebase, test, drop, or continue carrying.
+    validations:
+      required: true

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "cadence",
+    "color": "0e8a16",
+    "description": "Weekly upstream merge and release cadence work"
+  },
+  {
+    "name": "carry",
+    "color": "d93f0b",
+    "description": "Private kernel carry patch work"
+  },
+  {
+    "name": "upstream",
+    "color": "1d76db",
+    "description": "Submission, review, or reduction work against upstream Linux"
+  },
+  {
+    "name": "rt",
+    "color": "5319e7",
+    "description": "PREEMPT_RT build, boot, and validation work"
+  },
+  {
+    "name": "packaging",
+    "color": "fbca04",
+    "description": "RPM build, release, and installer packaging work"
+  },
+  {
+    "name": "deployment",
+    "color": "0052cc",
+    "description": "Rollout and validation work on named hosts"
+  },
+  {
+    "name": "ci",
+    "color": "c2e0c6",
+    "description": "GitHub Actions and automation work"
+  }
+]

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -204,8 +204,8 @@ jobs:
           body: |
             ## XR Kernel Release
 
-            Built from tag `${{ github.ref_name }}` with patches from
-            [XoxdWM](https://github.com/Jesssullivan/XoxdWM/tree/main/patches).
+            Built from tag `${{ github.ref_name }}` with carry patches from
+            [`xr/patches`](https://github.com/tinyland-inc/linux-xr/tree/xr/main/xr/patches).
 
             ### Variants
             - **kernel-xr** (generic) — standard preemption
@@ -218,13 +218,9 @@ jobs:
 
             ### Install
             ```bash
-            # Generic variant
-            sudo dnf install ./kernel-xr-*.x86_64.rpm
-
-            # RT variant
-            sudo dnf install ./kernel-xr-rt-*.x86_64.rpm
-
-            sudo reboot
+            # Choose one:
+            curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | bash
+            curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
             ```
 
             ### Verify

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,70 @@
+name: Publish Pages
+
+on:
+  push:
+    branches: ['xr/main']
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - name: Build Jekyll site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
+
+      - name: Generate latest release manifest
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const { owner, repo } = context.repo;
+            const data = await github.rest.repos.getLatestRelease({ owner, repo });
+            const payload = {
+              tag_name: data.data.tag_name,
+              published_at: data.data.published_at,
+              html_url: data.data.html_url,
+              assets: data.data.assets.map((asset) => ({
+                name: asset.name,
+                size: asset.size,
+                browser_download_url: asset.browser_download_url,
+              })),
+            };
+            fs.mkdirSync(path.join("_site", "releases"), { recursive: true });
+            fs.writeFileSync(
+              path.join("_site", "releases", "latest.json"),
+              JSON.stringify(payload, null, 2) + "\n",
+            );
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,63 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - xr/main
+    paths:
+      - '.github/labels.json'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync repository labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const labels = JSON.parse(fs.readFileSync('.github/labels.json', 'utf8'));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const byName = new Map(existing.map((label) => [label.name, label]));
+
+            for (const label of labels) {
+              const current = byName.get(label.name);
+              if (current) {
+                const currentDescription = current.description || '';
+                if (
+                  current.color.toLowerCase() !== label.color.toLowerCase() ||
+                  currentDescription !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner,
+                    repo,
+                    name: current.name,
+                    new_name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              } else {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              }
+            }

--- a/.github/workflows/weekly-cadence.yml
+++ b/.github/workflows/weekly-cadence.yml
@@ -1,0 +1,64 @@
+name: Weekly Cadence
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cadence:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch upstream refs
+        run: |
+          git fetch --no-tags --prune https://github.com/torvalds/linux.git master:refs/remotes/upstream/master
+          git fetch --tags --prune https://github.com/gregkh/linux.git master:refs/remotes/stable/master
+
+      - name: Generate cadence report
+        run: |
+          chmod +x xr/scripts/generate-cadence-report.sh
+          xr/scripts/generate-cadence-report.sh \
+            --base-ref HEAD \
+            --upstream-ref refs/remotes/upstream/master \
+            --stable-ref refs/remotes/stable/master \
+            --output cadence-report.md
+          sed -n '1,200p' cadence-report.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cadence-report
+          path: cadence-report.md
+          retention-days: 30
+
+      - name: Open cadence issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('cadence-report.md', 'utf8');
+            const date = new Date().toISOString().slice(0, 10);
+            const payload = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `cadence: ${date} weekly upstream watch`,
+              body,
+            };
+
+            try {
+              await github.rest.issues.create({ ...payload, labels: ['cadence'] });
+            } catch (error) {
+              if ((error.message || '').includes('Label does not exist')) {
+                await github.rest.issues.create(payload);
+              } else {
+                throw error;
+              }
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,8 @@ modules.order
 !.editorconfig
 !.get_maintainer.ignore
 !.gitattributes
+!/.github/
+!/.github/**
 !.gitignore
 !.kunitconfig
 !.mailmap
@@ -131,6 +133,8 @@ patches-*
 # quilt's files
 patches
 series
+!/xr/patches/
+!/xr/patches/**
 
 # ctags files
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ patches
 series
 !/xr/patches/
 !/xr/patches/**
+!/xr/patches/series
 
 # ctags files
 tags

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Build optimizations:
 - `CONFIG_DEBUG_INFO=n` — reduces link-time memory from ~8GB to ~2GB
 - Parallelism capped at `-j4` — prevents OOM on memory-constrained runners
 - ccache with `save-always: true` — warm builds ~1h vs cold ~2h
+- `weekly-cadence.yml` — fetches upstream refs, renders a markdown report from `xr/patches/series`, and opens a weekly cadence issue
 
 ## Version scheme
 
@@ -290,11 +291,12 @@ Build optimizations:
 
 ## Kernel upgrade workflow
 
-1. `git fetch upstream && git merge upstream/master`
-2. Rebase `xr/main` onto new master
-3. Update `xr/config/base.config` if honey's base kernel changes
+1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`
+2. Merge or rebase onto the latest upstream Linux commit that still keeps the carry set clean
+3. Update `xr/config/base.config` if `honey`'s running base kernel changes
 4. Tag: `git tag -a v6.20.1-xr1 -m "XR kernel 6.20.1"`
 5. CI builds + publishes RPMs
+6. Promote only after `honey` and `yoga` validation
 
 ## Upstream status
 
@@ -304,3 +306,5 @@ Build optimizations:
 | QP table + RC offset (raika-xino) | Never submitted | Needs amd-gfx submission |
 | EDID non_desktop quirk (BIG/0x1234) | Not submitted | Submit to drm-misc |
 | PREEMPT_RT | Mainline since 6.12 | N/A |
+
+Carry patch order is defined in `xr/patches/series`.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,36 @@ Builds are run on tinyland-inc/GloriousFlywheel infrastructure, including machin
 
 Fork of `torvalds/linux` with CI-built RPMs carrying VR/XR patches.
 
+## Current State
+
+As of 2026-04-11:
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Release artifacts | Proven | Latest public release ships generic and RT RPMs. |
+| `honey` rollout | Proven (generic) | `honey` is currently running `6.19.5-5.xr.el10`. |
+| `honey` RT default boot | Gated | RT artifacts exist, but RT is not yet the default documented lane. |
+| `yoga` rollout | Pending | `yoga` is still on the stock Rocky 10 kernel. |
+| Install surface | In progress | GitHub Pages and stable installer paths live in `site/`. |
+| Patch carry set | Localized | Kernel-owned carry patches live under `xr/patches/`. |
+
+## Public Surfaces
+
+- Releases: <https://github.com/tinyland-inc/linux-xr/releases>
+- Stable install docs: `https://tinyland-inc.github.io/linux-xr/`
+- Generic installer: `https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh`
+- RT installer: `https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh`
+- Carry patches: [`xr/patches`](xr/patches)
+
 ## What's patched
 
 | Patch | Purpose |
 |-------|---------|
 | `0007-vesa-dsc-bpp.patch` | VESA DisplayID DSC BPP parser, QP table + RC offset fixes for 8bpc 4:4:4 @ 8 BPP |
 | `bigscreen-beyond-edid.patch` | EDID non-desktop quirk for Beyond (BIG/0x1234 + 0x5095) |
-| `patch-6.19.3-rt1.patch` | PREEMPT_RT real-time scheduling (RT variant only) |
+| `patch-6.19.3-rt1.patch` | PREEMPT_RT real-time scheduling (RT variant only, downloaded from kernel.org) |
 
-Patches are maintained in [XoxdWM/patches](https://github.com/tinyland-inc/XoxdWM/tree/main/patches) and fetched at build time.
+Patches are maintained in this repository under [`xr/patches`](xr/patches).
 
 RT opinions come primarily from very large AD/DA and related busses used for sensors on BCI server (~100:100 channels of carefully clocked I/O; uses external C777 sample wordclock).
 
@@ -88,7 +109,9 @@ Order of operations for first deployment on a Dell T7810:
 
 ### Phase 1: Install kernel
 
-- [ ] Download RPMs from [Releases](https://github.com/Jesssullivan/linux-xr/releases) or CI artifacts
+- [ ] Install from [Releases](https://github.com/tinyland-inc/linux-xr/releases) or the stable Pages installer surface
+- [ ] Generic: `curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | bash`
+- [ ] RT: `curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash`
 - [ ] `sudo dnf install ./kernel-xr-6.19.5-*.xr.el10.x86_64.rpm`
 - [ ] Generate initramfs: `sudo dracut --force /boot/initramfs-6.19.5-rt1-1.xr.el10.img 6.19.5-rt1-1.xr.el10`
 - [ ] Create BLS boot entry (see [Boot entry setup](#boot-entry-setup))

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,0 +1,4 @@
+title: linux-xr
+description: Stable install and rollout docs for the XR kernel fork.
+markdown: kramdown
+permalink: pretty

--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -1,0 +1,20 @@
+---
+title: honey
+---
+
+# honey
+
+Role: primary XR validation host.
+
+Current known state from the 2026-04-11 audit:
+
+- running kernel: `6.19.5-5.xr.el10`
+- installed generic XR kernels: present
+- installed RT RPMs: present, but not the documented default lane
+- OpenXR userspace present
+- Monado unit files present but disabled
+
+Current rollout stance:
+
+- generic XR kernel: active and documented
+- RT XR kernel: still gated pending repeatable boot and latency validation

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -8,6 +8,8 @@ Baseline date: 2026-04-11
 
 ## Carry Set
 
+Carry order is defined in `xr/patches/series`.
+
 - `xr/patches/0007-vesa-dsc-bpp.patch`
   - state: carry
   - reason: DSC fixed-BPP parsing/passthrough work remains unmerged upstream
@@ -23,3 +25,5 @@ The weekly maintenance intent is:
 2. classify whether the carry set still applies cleanly
 3. build generic and RT variants
 4. promote only after host validation
+
+After merge, `.github/workflows/weekly-cadence.yml` is the repo's scheduled mechanism for producing that weekly report and opening a cadence issue.

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -1,0 +1,25 @@
+---
+title: Upstream Status
+---
+
+# Upstream Status
+
+Baseline date: 2026-04-11
+
+## Carry Set
+
+- `xr/patches/0007-vesa-dsc-bpp.patch`
+  - state: carry
+  - reason: DSC fixed-BPP parsing/passthrough work remains unmerged upstream
+- `xr/patches/bigscreen-beyond-edid.patch`
+  - state: upstream candidate
+  - reason: Bigscreen Beyond non-desktop quirk still absent from upstream `drm_edid.c`
+
+## Kernel Cadence
+
+The weekly maintenance intent is:
+
+1. inspect upstream stable and longterm movement
+2. classify whether the carry set still applies cleanly
+3. build generic and RT variants
+4. promote only after host validation

--- a/site/docs/yoga.md
+++ b/site/docs/yoga.md
@@ -1,0 +1,18 @@
+---
+title: yoga
+---
+
+# yoga
+
+Role: secondary Rocky 10 rollout and desktop/dev validation host.
+
+Current known state from the 2026-04-11 audit:
+
+- running kernel: `6.12.0-124.45.1.el10_1.x86_64`
+- no XR kernel install detected
+- no local `linux-xr` or `XoxdWM` checkout detected in `~/git`
+
+Current rollout stance:
+
+- next target for generic XR installer validation
+- not yet a documented RT target

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,26 @@
+---
+title: linux-xr
+---
+
+# linux-xr
+
+Stable install and rollout surface for the XR kernel fork.
+
+## Current State
+
+- Latest release artifacts ship both generic and RT RPMs.
+- `honey` currently runs the generic XR kernel lane.
+- RT remains available, but it is still a gated rollout path.
+- `yoga` is the next Rocky 10 rollout target.
+
+## Install
+
+- [Generic installer](/linux-xr/install/rocky10-generic.sh)
+- [RT installer](/linux-xr/install/rocky10-rt.sh)
+- [Install notes](install/)
+
+## Host Docs
+
+- [honey](/linux-xr/docs/honey/)
+- [yoga](/linux-xr/docs/yoga/)
+- [Upstream status](/linux-xr/docs/upstream-status/)

--- a/site/install.md
+++ b/site/install.md
@@ -1,0 +1,19 @@
+---
+title: Install
+---
+
+# Install
+
+Stable script entrypoints:
+
+```bash
+curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | bash
+curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
+```
+
+The scripts download the latest release assets, install the matching RPM set, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
+
+## Variants
+
+- `generic`: default documented rollout lane for Rocky 10 hosts
+- `rt`: gated lane for hosts that have passed the RT boot and latency checklist

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
+API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
+MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "Missing required command: $1" >&2
+        exit 1
+    }
+}
+
+need_cmd curl
+need_cmd python3
+need_cmd sudo
+need_cmd dnf
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/latest.json"; then
+    curl -fsSL "$API_URL" -o "$TMPDIR/latest.json"
+fi
+
+mapfile -t URLS < <(python3 - "$TMPDIR/latest.json" <<'PY'
+import json, re, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+for asset in data.get("assets", []):
+    name = asset.get("name", "")
+    url = asset.get("browser_download_url", "")
+    if not url:
+        continue
+    if name.startswith("kernel-xr-rt-"):
+        continue
+    if re.fullmatch(r"kernel-xr(?:-(?:devel|headers))?-[^/]+\.rpm", name):
+        print(url)
+PY
+)
+
+TAG="$(python3 - "$TMPDIR/latest.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    print(json.load(fh)["tag_name"])
+PY
+)"
+
+if [ "${#URLS[@]}" -eq 0 ]; then
+    echo "No generic RPM assets found in latest release." >&2
+    exit 1
+fi
+
+cd "$TMPDIR"
+for url in "${URLS[@]}"; do
+    curl -fL -O "$url"
+done
+
+sudo dnf install -y ./*.rpm
+
+if command -v grubby >/dev/null 2>&1; then
+    kernel_path="$(ls -1 /boot/vmlinuz-*xr.el10* 2>/dev/null | grep -v 'rt' | sort -V | tail -1 || true)"
+    if [ -n "${kernel_path:-}" ]; then
+        sudo grubby --set-default "$kernel_path" || true
+    fi
+fi
+
+echo "Installed linux-xr generic release ${TAG}."
+echo "Reboot, then verify with: uname -r"

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
+API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
+MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "Missing required command: $1" >&2
+        exit 1
+    }
+}
+
+need_cmd curl
+need_cmd python3
+need_cmd sudo
+need_cmd dnf
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/latest.json"; then
+    curl -fsSL "$API_URL" -o "$TMPDIR/latest.json"
+fi
+
+mapfile -t URLS < <(python3 - "$TMPDIR/latest.json" <<'PY'
+import json, re, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+for asset in data.get("assets", []):
+    name = asset.get("name", "")
+    url = asset.get("browser_download_url", "")
+    if not url:
+        continue
+    if re.fullmatch(r"kernel-xr-rt(?:-(?:devel|headers))?-[^/]+\.rpm", name):
+        print(url)
+PY
+)
+
+TAG="$(python3 - "$TMPDIR/latest.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    print(json.load(fh)["tag_name"])
+PY
+)"
+
+if [ "${#URLS[@]}" -eq 0 ]; then
+    echo "No RT RPM assets found in latest release." >&2
+    exit 1
+fi
+
+cd "$TMPDIR"
+for url in "${URLS[@]}"; do
+    curl -fL -O "$url"
+done
+
+sudo dnf install -y ./*.rpm
+
+if command -v grubby >/dev/null 2>&1; then
+    kernel_path="$(ls -1 /boot/vmlinuz-*rt*.xr.el10* 2>/dev/null | sort -V | tail -1 || true)"
+    if [ -n "${kernel_path:-}" ]; then
+        sudo grubby --set-default "$kernel_path" || true
+    fi
+fi
+
+echo "Installed linux-xr RT release ${TAG}."
+echo "Reboot, then verify with: uname -r"

--- a/xr/patches/0007-vesa-dsc-bpp.patch
+++ b/xr/patches/0007-vesa-dsc-bpp.patch
@@ -1,0 +1,391 @@
+From 27bc161cc783432bcd0fa989a676b7487eab23b1 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Fri, 27 Feb 2026 09:09:41 +0100
+Subject: [PATCH 7/8] vesa-dsc-bpp
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ .../gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |  16 +++
+ .../drm/amd/display/dc/dml/dsc/qp_tables.h    |   4 +-
+ .../drm/amd/display/dc/dml/dsc/rc_calc_fpu.c  |   2 +-
+ drivers/gpu/drm/drm_displayid_internal.h      |  11 ++
+ drivers/gpu/drm/drm_edid.c                    | 102 +++++++++++-------
+ include/drm/drm_connector.h                   |   6 ++
+ include/drm/drm_modes.h                       |  10 ++
+ 7 files changed, 112 insertions(+), 39 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index bc9aca604aa0..47583196cfa8 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -6779,6 +6779,11 @@ static void fill_stream_properties_from_drm_display_mode(
+ 
+ 	stream->output_color_space = get_output_color_space(timing_out, connector_state);
+ 	stream->content_type = get_output_content_type(connector_state);
++
++	/* DisplayID Type VII pass-through timings. */
++	if (mode_in->dsc_passthrough_timings_support && info->dp_dsc_bpp_x16 != 0) {
++		stream->timing.dsc_fixed_bits_per_pixel_x16 = info->dp_dsc_bpp_x16;
++	}
+ }
+ 
+ static void fill_audio_info(struct audio_info *audio_info,
+@@ -7237,6 +7242,7 @@ create_stream_for_sink(struct drm_connector *connector,
+ 	struct drm_display_mode mode;
+ 	struct drm_display_mode saved_mode;
+ 	struct drm_display_mode *freesync_mode = NULL;
++	struct drm_display_mode *dsc_passthru_mode = NULL;
+ 	bool native_mode_found = false;
+ 	bool recalculate_timing = false;
+ 	bool scale = dm_state->scaling != RMX_OFF;
+@@ -7328,6 +7334,16 @@ create_stream_for_sink(struct drm_connector *connector,
+ 		}
+ 	}
+ 
++	list_for_each_entry(dsc_passthru_mode, &connector->modes, head) {
++		if (dsc_passthru_mode->hdisplay == mode.hdisplay &&
++		    dsc_passthru_mode->vdisplay == mode.vdisplay &&
++		    drm_mode_vrefresh(dsc_passthru_mode) == mode_refresh) {
++			mode.dsc_passthrough_timings_support =
++				dsc_passthru_mode->dsc_passthrough_timings_support;
++			break;
++		}
++	}
++
+ 	if (recalculate_timing)
+ 		drm_mode_set_crtcinfo(&saved_mode, 0);
+ 
+diff --git a/drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h b/drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h
+index dcff0dd2b6a1..622abb69ea00 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h
++++ b/drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h
+@@ -63,7 +63,7 @@ static const qp_table   qp_table_444_8bpc_max = {
+ 	{ 6.5, { 4, 6, 7, 8, 8, 8, 9, 10, 11, 11, 12, 12, 12, 13, 15} },
+ 	{   7, { 4, 5, 7, 7, 8, 8, 8, 9, 10, 11, 11, 12, 12, 13, 14} },
+ 	{ 7.5, { 4, 5, 6, 7, 7, 8, 8, 9, 10, 10, 11, 11, 12, 13, 14} },
+-	{   8, { 4, 4, 5, 6, 7, 7, 7, 8, 9, 10, 10, 11, 11, 12, 13} },
++	{   8, { 4, 4, 5, 6, 7, 7, 7, 8, 9, 10, 11, 12, 13, 13, 15} },
+ 	{ 8.5, { 4, 4, 5, 6, 7, 7, 7, 8, 9, 10, 10, 11, 11, 12, 13} },
+ 	{   9, { 3, 4, 5, 6, 7, 7, 7, 8, 9, 9, 10, 10, 11, 11, 13} },
+ 	{ 9.5, { 3, 4, 5, 6, 7, 7, 7, 8, 9, 9, 10, 10, 11, 11, 13} },
+@@ -211,7 +211,7 @@ static const qp_table   qp_table_444_8bpc_min = {
+ 	{ 6.5, { 0, 1, 2, 3, 4, 4, 5, 5, 5, 5, 6, 6, 6, 9, 14} },
+ 	{   7, { 0, 0, 2, 2, 4, 4, 4, 4, 4, 5, 5, 6, 6, 9, 13} },
+ 	{ 7.5, { 0, 0, 2, 2, 3, 4, 4, 4, 4, 4, 5, 5, 6, 9, 13} },
+-	{   8, { 0, 0, 1, 1, 3, 3, 3, 3, 3, 4, 5, 5, 5, 8, 12} },
++	{   8, { 0, 0, 1, 1, 3, 3, 3, 3, 3, 3, 5, 5, 5, 7, 13} },
+ 	{ 8.5, { 0, 0, 1, 1, 3, 3, 3, 3, 3, 4, 5, 5, 5, 8, 12} },
+ 	{   9, { 0, 0, 1, 1, 3, 3, 3, 3, 3, 3, 5, 5, 5, 7, 12} },
+ 	{ 9.5, { 0, 0, 1, 1, 3, 3, 3, 3, 3, 3, 5, 5, 5, 7, 12} },
+diff --git a/drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c b/drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c
+index ef75eb7d5adc..8804419871d0 100644
+--- a/drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c
++++ b/drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c
+@@ -123,7 +123,7 @@ static void get_ofs_set(qp_set ofs, enum colour_mode mode, float bpp)
+ 		*p++ = (bpp <= 12) ? (-8) : ((bpp >= 15) ? (-6) : (-8 + dsc_roundf((bpp - 12) * (2 / 3.0))));
+ 		*p++ = (bpp <= 12) ? (-10) : ((bpp >= 15) ? (-8) : (-10 + dsc_roundf((bpp - 12) * (2 / 3.0))));
+ 		*p++ = -10;
+-		*p++ = (bpp <=  6) ? (-12) : ((bpp >=  8) ? (-10) : (-12 + dsc_roundf((bpp -  6) * (2 / 2.0))));
++		*p++ = (bpp <=  6) ? (-12) : ((bpp >=  8) ? (-12) : (-12 + dsc_roundf((bpp -  6) * (2 / 2.0))));
+ 		*p++ = -12;
+ 		*p++ = -12;
+ 		*p++ = -12;
+diff --git a/drivers/gpu/drm/drm_displayid_internal.h b/drivers/gpu/drm/drm_displayid_internal.h
+index 5b1b32f73516..8f1a2f33ca1a 100644
+--- a/drivers/gpu/drm/drm_displayid_internal.h
++++ b/drivers/gpu/drm/drm_displayid_internal.h
+@@ -97,6 +97,7 @@ struct displayid_header {
+ 	u8 ext_count;
+ } __packed;
+ 
++#define DISPLAYID_BLOCK_REV	GENMASK(2, 0)
+ struct displayid_block {
+ 	u8 tag;
+ 	u8 rev;
+@@ -125,6 +126,7 @@ struct displayid_detailed_timings_1 {
+ 	__le16 vsw;
+ } __packed;
+ 
++#define DISPLAYID_BLOCK_PASSTHROUGH_TIMINGS_SUPPORT	BIT(3)
+ struct displayid_detailed_timing_block {
+ 	struct displayid_block base;
+ 	struct displayid_detailed_timings_1 timings[];
+@@ -137,19 +139,28 @@ struct displayid_formula_timings_9 {
+ 	u8 vrefresh;
+ } __packed;
+ 
++#define DISPLAYID_BLOCK_DESCRIPTOR_PAYLOAD_BYTES	GENMASK(6, 4)
+ struct displayid_formula_timing_block {
+ 	struct displayid_block base;
+ 	struct displayid_formula_timings_9 timings[];
+ } __packed;
+ 
++#define DISPLAYID_VESA_DP_TYPE		GENMASK(2, 0)
+ #define DISPLAYID_VESA_MSO_OVERLAP	GENMASK(3, 0)
+ #define DISPLAYID_VESA_MSO_MODE		GENMASK(6, 5)
++#define DISPLAYID_VESA_DSC_BPP_INT	GENMASK(5, 0)
++#define DISPLAYID_VESA_DSC_BPP_FRACT	GENMASK(3, 0)
++
++#define DISPLAYID_VESA_DP_TYPE_EDP	0
++#define DISPLAYID_VESA_DP_TYPE_DP	1
+ 
+ struct displayid_vesa_vendor_specific_block {
+ 	struct displayid_block base;
+ 	u8 oui[3];
+ 	u8 data_structure_type;
+ 	u8 mso;
++	u8 dsc_bpp_int;
++	u8 dsc_bpp_fract;
+ } __packed;
+ 
+ /*
+diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
+index 056eff8cbd1a..26d53a548a27 100644
+--- a/drivers/gpu/drm/drm_edid.c
++++ b/drivers/gpu/drm/drm_edid.c
+@@ -45,6 +45,7 @@
+ #include <drm/drm_edid.h>
+ #include <drm/drm_eld.h>
+ #include <drm/drm_encoder.h>
++#include <drm/drm_fixed.h>
+ #include <drm/drm_print.h>
+ 
+ #include "drm_crtc_internal.h"
+@@ -6566,12 +6567,13 @@ static void drm_get_monitor_range(struct drm_connector *connector,
+ 		    info->monitor_range.min_vfreq, info->monitor_range.max_vfreq);
+ }
+ 
+-static void drm_parse_vesa_mso_data(struct drm_connector *connector,
+-				    const struct displayid_block *block)
++static void drm_parse_vesa_specific_block(struct drm_connector *connector,
++					  const struct displayid_block *block)
+ {
+ 	struct displayid_vesa_vendor_specific_block *vesa =
+ 		(struct displayid_vesa_vendor_specific_block *)block;
+ 	struct drm_display_info *info = &connector->display_info;
++	int dp_type;
+ 
+ 	if (block->num_bytes < 3) {
+ 		drm_dbg_kms(connector->dev,
+@@ -6583,51 +6585,73 @@ static void drm_parse_vesa_mso_data(struct drm_connector *connector,
+ 	if (oui(vesa->oui[0], vesa->oui[1], vesa->oui[2]) != VESA_IEEE_OUI)
+ 		return;
+ 
+-	if (sizeof(*vesa) != sizeof(*block) + block->num_bytes) {
++	if (block->num_bytes < 5) {
+ 		drm_dbg_kms(connector->dev,
+ 			    "[CONNECTOR:%d:%s] Unexpected VESA vendor block size\n",
+ 			    connector->base.id, connector->name);
+ 		return;
+ 	}
+ 
+-	switch (FIELD_GET(DISPLAYID_VESA_MSO_MODE, vesa->mso)) {
+-	default:
+-		drm_dbg_kms(connector->dev, "[CONNECTOR:%d:%s] Reserved MSO mode value\n",
++	dp_type = FIELD_GET(DISPLAYID_VESA_DP_TYPE, vesa->data_structure_type);
++	if (dp_type > 1) {
++		drm_dbg_kms(connector->dev, "[CONNECTOR:%d:%s] Reserved dp type value\n",
+ 			    connector->base.id, connector->name);
+-		fallthrough;
+-	case 0:
+-		info->mso_stream_count = 0;
+-		break;
+-	case 1:
+-		info->mso_stream_count = 2; /* 2 or 4 links */
+-		break;
+-	case 2:
+-		info->mso_stream_count = 4; /* 4 links */
+-		break;
+ 	}
+ 
+-	if (!info->mso_stream_count) {
++	/* MSO is only supported for eDP */
++	if (dp_type == DISPLAYID_VESA_DP_TYPE_EDP) {
++		switch (FIELD_GET(DISPLAYID_VESA_MSO_MODE, vesa->mso)) {
++		default:
++			drm_dbg_kms(connector->dev, "[CONNECTOR:%d:%s] Reserved MSO mode value\n",
++				    connector->base.id, connector->name);
++			fallthrough;
++		case 0:
++			info->mso_stream_count = 0;
++			break;
++		case 1:
++			info->mso_stream_count = 2; /* 2 or 4 links */
++			break;
++		case 2:
++			info->mso_stream_count = 4; /* 4 links */
++			break;
++		}
++	}
++
++	if (info->mso_stream_count) {
++		info->mso_pixel_overlap = FIELD_GET(DISPLAYID_VESA_MSO_OVERLAP, vesa->mso);
++		if (info->mso_pixel_overlap > 8) {
++			drm_dbg_kms(connector->dev,
++				    "[CONNECTOR:%d:%s] Reserved MSO pixel overlap value %u\n",
++				    connector->base.id, connector->name,
++				    info->mso_pixel_overlap);
++			info->mso_pixel_overlap = 8;
++		}
++		drm_dbg_kms(connector->dev,
++			    "[CONNECTOR:%d:%s] MSO stream count %u, pixel overlap %u\n",
++			    connector->base.id, connector->name,
++			    info->mso_stream_count, info->mso_pixel_overlap);
++	} else {
+ 		info->mso_pixel_overlap = 0;
++	}
++
++	if (block->num_bytes < 7) {
++		/* DSC bpp is optional */
+ 		return;
+ 	}
+ 
+-	info->mso_pixel_overlap = FIELD_GET(DISPLAYID_VESA_MSO_OVERLAP, vesa->mso);
+-	if (info->mso_pixel_overlap > 8) {
++	info->dp_dsc_bpp_x16 = FIELD_GET(DISPLAYID_VESA_DSC_BPP_INT, vesa->dsc_bpp_int) << 4 |
++			       FIELD_GET(DISPLAYID_VESA_DSC_BPP_FRACT, vesa->dsc_bpp_fract);
++
++	if (info->dp_dsc_bpp_x16 > 0) {
+ 		drm_dbg_kms(connector->dev,
+-			    "[CONNECTOR:%d:%s] Reserved MSO pixel overlap value %u\n",
++			    "[CONNECTOR:%d:%s] DSC bits per pixel " FXP_Q4_FMT "\n",
+ 			    connector->base.id, connector->name,
+-			    info->mso_pixel_overlap);
+-		info->mso_pixel_overlap = 8;
++			    FXP_Q4_ARGS(info->dp_dsc_bpp_x16));
+ 	}
+-
+-	drm_dbg_kms(connector->dev,
+-		    "[CONNECTOR:%d:%s] MSO stream count %u, pixel overlap %u\n",
+-		    connector->base.id, connector->name,
+-		    info->mso_stream_count, info->mso_pixel_overlap);
+ }
+ 
+-static void drm_update_mso(struct drm_connector *connector,
+-			   const struct drm_edid *drm_edid)
++static void drm_update_vesa_specific_block(struct drm_connector *connector,
++					   const struct drm_edid *drm_edid)
+ {
+ 	const struct displayid_block *block;
+ 	struct displayid_iter iter;
+@@ -6635,7 +6659,7 @@ static void drm_update_mso(struct drm_connector *connector,
+ 	displayid_iter_edid_begin(drm_edid, &iter);
+ 	displayid_iter_for_each(block, &iter) {
+ 		if (block->tag == DATA_BLOCK_2_VENDOR_SPECIFIC)
+-			drm_parse_vesa_mso_data(connector, block);
++			drm_parse_vesa_specific_block(connector, block);
+ 	}
+ 	displayid_iter_end(&iter);
+ }
+@@ -6672,6 +6696,7 @@ static void drm_reset_display_info(struct drm_connector *connector)
+ 	info->mso_stream_count = 0;
+ 	info->mso_pixel_overlap = 0;
+ 	info->max_dsc_bpp = 0;
++	info->dp_dsc_bpp_x16 = 0;
+ 
+ 	kfree(info->vics);
+ 	info->vics = NULL;
+@@ -6795,7 +6820,7 @@ static void update_display_info(struct drm_connector *connector,
+ 	if (edid->features & DRM_EDID_FEATURE_RGB_YCRCB422)
+ 		info->color_formats |= DRM_COLOR_FORMAT_YCBCR422;
+ 
+-	drm_update_mso(connector, drm_edid);
++	drm_update_vesa_specific_block(connector, drm_edid);
+ 
+ out:
+ 	if (drm_edid_has_internal_quirk(connector, EDID_QUIRK_NON_DESKTOP)) {
+@@ -6825,8 +6850,8 @@ static void update_display_info(struct drm_connector *connector,
+ }
+ 
+ static struct drm_display_mode *drm_mode_displayid_detailed(struct drm_device *dev,
+-							    const struct displayid_detailed_timings_1 *timings,
+-							    bool type_7)
++							    const struct displayid_block *block,
++							    const struct displayid_detailed_timings_1 *timings)
+ {
+ 	struct drm_display_mode *mode;
+ 	unsigned int pixel_clock = (timings->pixel_clock[0] |
+@@ -6842,11 +6867,16 @@ static struct drm_mode_displayid_detailed(struct drm_device *dev,
+ 	unsigned int vsync_width = le16_to_cpu(timings->vsw) + 1;
+ 	bool hsync_positive = le16_to_cpu(timings->hsync) & (1 << 15);
+ 	bool vsync_positive = le16_to_cpu(timings->vsync) & (1 << 15);
++	bool type_7 = block->tag == DATA_BLOCK_2_TYPE_7_DETAILED_TIMING;
+ 
+ 	mode = drm_mode_create(dev);
+ 	if (!mode)
+ 		return NULL;
+ 
++	if (type_7 && FIELD_GET(DISPLAYID_BLOCK_REV, block->rev) >= 1)
++		mode->dsc_passthrough_timings_support =
++			block->rev & DISPLAYID_BLOCK_PASSTHROUGH_TIMINGS_SUPPORT;
++
+ 	/* resolution is kHz for type VII, and 10 kHz for type I */
+ 	mode->clock = type_7 ? pixel_clock : pixel_clock * 10;
+ 	mode->hdisplay = hactive;
+@@ -6879,7 +6909,6 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
+ 	int num_timings;
+ 	struct drm_display_mode *newmode;
+ 	int num_modes = 0;
+-	bool type_7 = block->tag == DATA_BLOCK_2_TYPE_7_DETAILED_TIMING;
+ 	/* blocks must be multiple of 20 bytes length */
+ 	if (block->num_bytes % 20)
+ 		return 0;
+@@ -6888,7 +6917,7 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
+ 	for (i = 0; i < num_timings; i++) {
+ 		struct displayid_detailed_timings_1 *timings = &det->timings[i];
+ 
+-		newmode = drm_mode_displayid_detailed(connector->dev, timings, type_7);
++		newmode = drm_mode_displayid_detailed(connector->dev, block, timings);
+ 		if (!newmode)
+ 			continue;
+ 
+@@ -6935,7 +6964,8 @@ static int add_displayid_formula_modes(struct drm_connector *connector,
+ 	struct drm_display_mode *newmode;
+ 	int num_modes = 0;
+ 	bool type_10 = block->tag == DATA_BLOCK_2_TYPE_10_FORMULA_TIMING;
+-	int timing_size = 6 + ((formula_block->base.rev & 0x70) >> 4);
++	int timing_size = 6 +
++		FIELD_GET(DISPLAYID_BLOCK_DESCRIPTOR_PAYLOAD_BYTES, formula_block->base.rev);
+ 
+ 	/* extended blocks are not supported yet */
+ 	if (timing_size != 6)
+diff --git a/include/drm/drm_connector.h b/include/drm/drm_connector.h
+index fa4abfe8971e..a0f86e48192e 100644
+--- a/include/drm/drm_connector.h
++++ b/include/drm/drm_connector.h
+@@ -890,6 +890,12 @@ struct drm_display_info {
+ 	 */
+ 	u32 max_dsc_bpp;
+ 
++	/**
++	 * @dp_dsc_bpp: DP Display-Stream-Compression (DSC) timing's target
++	 * DSC bits per pixel in 6.4 fixed point format. 0 means undefined.
++	 */
++	u16 dp_dsc_bpp_x16;
++
+ 	/**
+ 	 * @vics: Array of vics_len VICs. Internal to EDID parsing.
+ 	 */
+diff --git a/include/drm/drm_modes.h b/include/drm/drm_modes.h
+index b9bb92e4b029..312e5c03af9a 100644
+--- a/include/drm/drm_modes.h
++++ b/include/drm/drm_modes.h
+@@ -417,6 +417,16 @@ struct drm_display_mode {
+ 	 */
+ 	enum hdmi_picture_aspect picture_aspect_ratio;
+ 
++	/**
++	 * @dsc_passthrough_timing_support:
++	 *
++	 * Indicates whether this mode timing descriptor is supported
++	 * with specific target DSC bits per pixel only.
++	 *
++	 * VESA vendor-specific data block shall exist with the relevant
++	 * DSC bits per pixel declaration when this flag is set to true.
++	 */
++	bool dsc_passthrough_timings_support;
+ };
+ 
+ /**
+-- 
+2.53.0

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -1,0 +1,10 @@
+# Carry Patches
+
+This directory is the kernel repo's source of truth for the private carry set.
+
+Current carry classification:
+
+- `0007-vesa-dsc-bpp.patch`: carry while the DSC fixed-BPP series remains unmerged upstream
+- `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk
+
+The build and release workflows should source patches from here rather than another repo.

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -2,6 +2,8 @@
 
 This directory is the kernel repo's source of truth for the private carry set.
 
+Patch application order is defined in `series`.
+
 Current carry classification:
 
 - `0007-vesa-dsc-bpp.patch`: carry while the DSC fixed-BPP series remains unmerged upstream

--- a/xr/patches/bigscreen-beyond-edid.patch
+++ b/xr/patches/bigscreen-beyond-edid.patch
@@ -1,0 +1,31 @@
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Subject: [PATCH] drm/edid: add non-desktop quirk to Bigscreen Beyond HMD
+
+The Bigscreen Beyond is a non-desktop output and should be marked as
+such. Without this quirk, desktop environments treat it as a regular
+monitor instead of a VR headset.
+
+EDID manufacturer code: "BIG" (PnP ID 0x0927)
+- Product 0x1234: Bigscreen Beyond (original)
+- Product 0x5095: Bigscreen Beyond 2e
+
+Ref: https://www.phoronix.com/news/Linux-Bigscreen-Beyond-VR
+Ref: https://www.mail-archive.com/dri-devel@lists.freedesktop.org/msg493878.html
+---
+ drivers/gpu/drm/drm_edid.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
+index XXXXXXX..YYYYYYY 100644
+--- a/drivers/gpu/drm/drm_edid.c
++++ b/drivers/gpu/drm/drm_edid.c
+@@ -194,6 +194,10 @@ static const struct edid_quirk {
+ 	/* AUO laptop panel produces high CRC errors */
+ 	EDID_QUIRK('A', 'U', 'O', 0x305c, EDID_QUIRK_FORCE_10BPC),
+
++	/* Bigscreen Beyond VR Headsets */
++	EDID_QUIRK('B', 'I', 'G', 0x1234, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('B', 'I', 'G', 0x5095, BIT(EDID_QUIRK_NON_DESKTOP)),
++
+ 	/* BOE model on HP Pavilion 15-n233sl */
+ 	EDID_QUIRK('B', 'O', 'E', 0x0786, EDID_QUIRK_NO_EDID_QUIRK_FORCE_6BPC),

--- a/xr/patches/series
+++ b/xr/patches/series
@@ -1,0 +1,2 @@
+0007-vesa-dsc-bpp.patch
+bigscreen-beyond-edid.patch

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -15,6 +15,7 @@ RT_VERSION=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATCH_DIR="${XR_DIR}/patches"
+SERIES_FILE="${PATCH_DIR}/series"
 
 usage() {
     echo "Usage: $0 --kernel-version VER --xr-release REL [--rt-version RT_VER]"
@@ -97,10 +98,17 @@ fi
 # --- Step 3: Stage XR carry patches from this repo ---
 echo ">>> Staging XR patches from ${PATCH_DIR}..."
 
-PATCHES=(
-    "0007-vesa-dsc-bpp.patch"
-    "bigscreen-beyond-edid.patch"
-)
+if [[ ! -f "${SERIES_FILE}" ]]; then
+    echo "ERROR: ${SERIES_FILE} not found."
+    exit 1
+fi
+
+mapfile -t PATCHES < <(grep -vE '^[[:space:]]*(#|$)' "${SERIES_FILE}")
+
+if [[ "${#PATCHES[@]}" -eq 0 ]]; then
+    echo "ERROR: ${SERIES_FILE} does not list any carry patches."
+    exit 1
+fi
 
 for patch in "${PATCHES[@]}"; do
     echo "    ${patch}"

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -14,8 +14,7 @@ XR_RELEASE="1"
 RT_VERSION=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-EXWM_REPO="tinyland-inc/XoxdWM"
-EXWM_BRANCH="main"
+PATCH_DIR="${XR_DIR}/patches"
 
 usage() {
     echo "Usage: $0 --kernel-version VER --xr-release REL [--rt-version RT_VER]"
@@ -95,8 +94,8 @@ if [[ -n "${RT_VERSION}" ]]; then
     fi
 fi
 
-# --- Step 3: Fetch XR patches from exwm repo ---
-echo ">>> Fetching XR patches from ${EXWM_REPO}..."
+# --- Step 3: Stage XR carry patches from this repo ---
+echo ">>> Staging XR patches from ${PATCH_DIR}..."
 
 PATCHES=(
     "0007-vesa-dsc-bpp.patch"
@@ -104,9 +103,12 @@ PATCHES=(
 )
 
 for patch in "${PATCHES[@]}"; do
-    PATCH_URL="https://raw.githubusercontent.com/${EXWM_REPO}/${EXWM_BRANCH}/patches/${patch}"
     echo "    ${patch}"
-    curl -fSL -o "${RPMBUILD}/SOURCES/${patch}" "${PATCH_URL}"
+    if [[ ! -f "${PATCH_DIR}/${patch}" ]]; then
+        echo "ERROR: missing carry patch ${PATCH_DIR}/${patch}"
+        exit 1
+    fi
+    install -m 0644 "${PATCH_DIR}/${patch}" "${RPMBUILD}/SOURCES/${patch}"
 done
 
 # --- Step 4: Copy base config ---

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# generate-cadence-report.sh — Render a markdown report for the weekly upstream watch.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PATCH_DIR="${XR_DIR}/patches"
+SERIES_FILE="${PATCH_DIR}/series"
+
+BASE_REF="HEAD"
+UPSTREAM_REF=""
+STABLE_REF=""
+OUTPUT="-"
+MAX_COMMITS=10
+
+usage() {
+    cat <<'EOF'
+Usage: generate-cadence-report.sh [options]
+
+Options:
+  --base-ref REF       Base branch or commit to inspect (default: HEAD)
+  --upstream-ref REF   Upstream Linux ref to compare against
+  --stable-ref REF     Stable Linux ref to compare against
+  --output PATH        Output markdown file ('-' for stdout)
+  --max-commits N      Number of commits to show per section (default: 10)
+  --help               Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-ref) BASE_REF="$2"; shift 2 ;;
+        --upstream-ref) UPSTREAM_REF="$2"; shift 2 ;;
+        --stable-ref) STABLE_REF="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --max-commits) MAX_COMMITS="$2"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+has_ref() {
+    git rev-parse --verify -q "$1^{commit}" >/dev/null 2>&1
+}
+
+short_ref() {
+    git rev-parse --short "$1" 2>/dev/null || echo "unavailable"
+}
+
+describe_ref() {
+    git describe --tags --abbrev=0 "$1" 2>/dev/null || echo "unavailable"
+}
+
+commit_list() {
+    local range="$1"
+    git log --format='- `%h` %s' --no-merges -n "${MAX_COMMITS}" "${range}" 2>/dev/null || true
+}
+
+carry_rows() {
+    local idx=1
+
+    if [[ ! -f "${SERIES_FILE}" ]]; then
+        echo "| n/a | `series missing` |"
+        return
+    fi
+
+    while IFS= read -r patch; do
+        [[ -z "${patch}" || "${patch}" =~ ^[[:space:]]*# ]] && continue
+        echo "| ${idx} | \`${patch}\` |"
+        idx=$((idx + 1))
+    done < "${SERIES_FILE}"
+}
+
+BASE_SHA="$(short_ref "${BASE_REF}")"
+GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+tmp_report="$(mktemp)"
+trap 'rm -f "${tmp_report}"' EXIT
+
+{
+    echo "# linux-xr Weekly Cadence Report"
+    echo
+    echo "- Generated: ${GENERATED_AT}"
+    echo "- Base ref: \`${BASE_REF}\` (\`${BASE_SHA}\`)"
+    echo
+    echo "## Carry Set"
+    echo
+    echo "| Order | Patch |"
+    echo "| --- | --- |"
+    carry_rows
+    echo
+    echo "## Upstream Summary"
+    echo
+
+    if [[ -n "${UPSTREAM_REF}" ]] && has_ref "${UPSTREAM_REF}"; then
+        MERGE_BASE="$(git merge-base "${BASE_REF}" "${UPSTREAM_REF}")"
+        UPSTREAM_ONLY="$(git rev-list --count "${MERGE_BASE}..${UPSTREAM_REF}")"
+        FORK_ONLY="$(git rev-list --count "${MERGE_BASE}..${BASE_REF}")"
+
+        echo "- Upstream ref: \`${UPSTREAM_REF}\` (\`$(short_ref "${UPSTREAM_REF}")\`)"
+        echo "- Latest upstream tag: \`$(describe_ref "${UPSTREAM_REF}")\`"
+        echo "- Merge base: \`$(git rev-parse --short "${MERGE_BASE}")\`"
+        echo "- Upstream-only commits since merge base: ${UPSTREAM_ONLY}"
+        echo "- Fork-only commits since merge base: ${FORK_ONLY}"
+        echo
+        echo "### Recent Upstream Commits"
+        echo
+        commits="$(commit_list "${MERGE_BASE}..${UPSTREAM_REF}")"
+        if [[ -n "${commits}" ]]; then
+            echo "${commits}"
+        else
+            echo "- none"
+        fi
+        echo
+        echo "### Recent Fork Commits"
+        echo
+        commits="$(commit_list "${MERGE_BASE}..${BASE_REF}")"
+        if [[ -n "${commits}" ]]; then
+            echo "${commits}"
+        else
+            echo "- none"
+        fi
+    else
+        echo "- Upstream ref unavailable in this checkout."
+    fi
+
+    echo
+    echo "## Stable Summary"
+    echo
+
+    if [[ -n "${STABLE_REF}" ]] && has_ref "${STABLE_REF}"; then
+        echo "- Stable ref: \`${STABLE_REF}\` (\`$(short_ref "${STABLE_REF}")\`)"
+        echo "- Latest stable tag: \`$(describe_ref "${STABLE_REF}")\`"
+    else
+        echo "- Stable ref unavailable in this checkout."
+    fi
+
+    echo
+    echo "## Next Actions"
+    echo
+    echo "1. Inspect the upstream-only commit list for merge candidates or conflicts."
+    echo "2. Check whether every patch in \`xr/patches/series\` still applies cleanly."
+    echo "3. Build both generic and RT variants if the carry set is unchanged."
+    echo "4. Promote only after named-host validation on \`honey\` and \`yoga\`."
+} > "${tmp_report}"
+
+if [[ "${OUTPUT}" == "-" ]]; then
+    cat "${tmp_report}"
+else
+    install -m 0644 "${tmp_report}" "${OUTPUT}"
+fi


### PR DESCRIPTION
## Summary
- move kernel-owned carried patches into xr/patches and make the build consume them locally
- add Pages-backed install/docs surfaces and stable Rocky 10 installer scripts
- add issue templates, label sync, and a weekly cadence workflow
- add a generated cadence report from the maintained carry series

## Why
This turns linux-xr into the canonical kernel/install repo with an owned carry set and an explicit maintenance loop instead of depending on another repo for patch state.

## Validation
- parsed workflow YAML and issue template YAML with Ruby YAML.load_file
- bash -n on xr/scripts/build-rpm.sh, xr/scripts/generate-cadence-report.sh, site/install/rocky10-generic.sh, and site/install/rocky10-rt.sh
- git diff --check
