### PR TITLE
Fix Pages manifest generation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,12 +25,6 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - name: Build Jekyll site
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./site
-          destination: ./_site
-
       - name: Generate latest release manifest
         uses: actions/github-script@v7
         with:
@@ -49,11 +43,17 @@ jobs:
                 browser_download_url: asset.browser_download_url,
               })),
             };
-            fs.mkdirSync(path.join("_site", "releases"), { recursive: true });
+            fs.mkdirSync(path.join("site", "releases"), { recursive: true });
             fs.writeFileSync(
-              path.join("_site", "releases", "latest.json"),
+              path.join("site", "releases", "latest.json"),
               JSON.stringify(payload, null, 2) + "\n",
             );
+
+      - name: Build Jekyll site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- generate releases/latest.json into site/releases before the Jekyll build
- avoid writing into the built _site artifact, which caused the initial Pages run to fail with EACCES

## Validation
- workflow YAML parses
- git diff --check
