### PR TITLE
Add non-root validation modes to installers

### DIFF
--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -9,10 +9,11 @@ Role: primary XR validation host.
 Current known state from the 2026-04-11 audit:
 
 - running kernel: `6.19.5-5.xr.el10`
-- installed generic XR kernels: present
+- installed generic XR kernels: `6.19.5-4`, `6.19.5-5`, and `6.19.5-6`
 - installed RT RPMs: present, but not the documented default lane
 - OpenXR userspace present
 - Monado unit files present but disabled
+- sudo requires an interactive password on this host
 
 Current rollout stance:
 

--- a/site/docs/yoga.md
+++ b/site/docs/yoga.md
@@ -9,8 +9,10 @@ Role: secondary Rocky 10 rollout and desktop/dev validation host.
 Current known state from the 2026-04-11 audit:
 
 - running kernel: `6.12.0-124.45.1.el10_1.x86_64`
+- installed kernels are still stock Rocky 10 builds
 - no XR kernel install detected
 - no local `linux-xr` or `XoxdWM` checkout detected in `~/git`
+- sudo requires an interactive password on this host
 
 Current rollout stance:
 

--- a/site/install.md
+++ b/site/install.md
@@ -13,6 +13,13 @@ curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
 
 The scripts download the latest release assets, install the matching RPM set, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
 
+For non-root validation or staged rollout work, both scripts also support:
+
+- `--print-assets` to show the selected release and RPM URLs without downloading
+- `--download-only` to fetch RPMs without installing them
+- `--target-dir <dir>` to control where downloaded RPMs are staged
+- `--no-set-default` to install without changing the default boot entry
+
 ## Variants
 
 - `generic`: default documented rollout lane for Rocky 10 hosts

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
 API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
 MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
+DOWNLOAD_ONLY=0
+PRINT_ASSETS=0
+SET_DEFAULT=1
+TARGET_DIR=""
 
 need_cmd() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -12,19 +16,46 @@ need_cmd() {
     }
 }
 
+usage() {
+    cat <<'EOF'
+Usage: rocky10-generic.sh [options]
+
+Options:
+  --print-assets      Print the selected release tag and RPM URLs, then exit
+  --download-only     Download RPMs without installing them
+  --target-dir DIR    Directory to place downloaded RPMs in
+  --no-set-default    Skip grubby default-kernel update after install
+  --help              Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --print-assets) PRINT_ASSETS=1; shift ;;
+        --download-only) DOWNLOAD_ONLY=1; shift ;;
+        --target-dir) TARGET_DIR="$2"; shift 2 ;;
+        --no-set-default) SET_DEFAULT=0; shift ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
 need_cmd curl
 need_cmd python3
-need_cmd sudo
-need_cmd dnf
 
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
-
-if ! curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/latest.json"; then
-    curl -fsSL "$API_URL" -o "$TMPDIR/latest.json"
+if (( PRINT_ASSETS == 0 && DOWNLOAD_ONLY == 0 )); then
+    need_cmd sudo
+    need_cmd dnf
 fi
 
-mapfile -t URLS < <(python3 - "$TMPDIR/latest.json" <<'PY'
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if ! curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/latest.json"; then
+    curl -fsSL "$API_URL" -o "$WORKDIR/latest.json"
+fi
+
+mapfile -t URLS < <(python3 - "$WORKDIR/latest.json" <<'PY'
 import json, re, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
@@ -40,7 +71,7 @@ for asset in data.get("assets", []):
 PY
 )
 
-TAG="$(python3 - "$TMPDIR/latest.json" <<'PY'
+TAG="$(python3 - "$WORKDIR/latest.json" <<'PY'
 import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     print(json.load(fh)["tag_name"])
@@ -52,14 +83,34 @@ if [ "${#URLS[@]}" -eq 0 ]; then
     exit 1
 fi
 
-cd "$TMPDIR"
+if (( PRINT_ASSETS == 1 )); then
+    echo "linux-xr generic release ${TAG}"
+    printf '%s\n' "${URLS[@]}"
+    exit 0
+fi
+
+if [[ -n "${TARGET_DIR}" ]]; then
+    mkdir -p "${TARGET_DIR}"
+    DOWNLOAD_DIR="$(cd "${TARGET_DIR}" && pwd)"
+elif (( DOWNLOAD_ONLY == 1 )); then
+    DOWNLOAD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/linux-xr-generic.XXXXXX")"
+else
+    DOWNLOAD_DIR="${WORKDIR}"
+fi
+
+cd "$DOWNLOAD_DIR"
 for url in "${URLS[@]}"; do
     curl -fL -O "$url"
 done
 
+if (( DOWNLOAD_ONLY == 1 )); then
+    echo "Downloaded linux-xr generic release ${TAG} to ${DOWNLOAD_DIR}"
+    exit 0
+fi
+
 sudo dnf install -y ./*.rpm
 
-if command -v grubby >/dev/null 2>&1; then
+if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
     kernel_path="$(ls -1 /boot/vmlinuz-*xr.el10* 2>/dev/null | grep -v 'rt' | sort -V | tail -1 || true)"
     if [ -n "${kernel_path:-}" ]; then
         sudo grubby --set-default "$kernel_path" || true

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
 API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
 MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
+DOWNLOAD_ONLY=0
+PRINT_ASSETS=0
+SET_DEFAULT=1
+TARGET_DIR=""
 
 need_cmd() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -12,19 +16,46 @@ need_cmd() {
     }
 }
 
+usage() {
+    cat <<'EOF'
+Usage: rocky10-rt.sh [options]
+
+Options:
+  --print-assets      Print the selected release tag and RPM URLs, then exit
+  --download-only     Download RPMs without installing them
+  --target-dir DIR    Directory to place downloaded RPMs in
+  --no-set-default    Skip grubby default-kernel update after install
+  --help              Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --print-assets) PRINT_ASSETS=1; shift ;;
+        --download-only) DOWNLOAD_ONLY=1; shift ;;
+        --target-dir) TARGET_DIR="$2"; shift 2 ;;
+        --no-set-default) SET_DEFAULT=0; shift ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
 need_cmd curl
 need_cmd python3
-need_cmd sudo
-need_cmd dnf
 
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
-
-if ! curl -fsSL "$MANIFEST_URL" -o "$TMPDIR/latest.json"; then
-    curl -fsSL "$API_URL" -o "$TMPDIR/latest.json"
+if (( PRINT_ASSETS == 0 && DOWNLOAD_ONLY == 0 )); then
+    need_cmd sudo
+    need_cmd dnf
 fi
 
-mapfile -t URLS < <(python3 - "$TMPDIR/latest.json" <<'PY'
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if ! curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/latest.json"; then
+    curl -fsSL "$API_URL" -o "$WORKDIR/latest.json"
+fi
+
+mapfile -t URLS < <(python3 - "$WORKDIR/latest.json" <<'PY'
 import json, re, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
@@ -38,7 +69,7 @@ for asset in data.get("assets", []):
 PY
 )
 
-TAG="$(python3 - "$TMPDIR/latest.json" <<'PY'
+TAG="$(python3 - "$WORKDIR/latest.json" <<'PY'
 import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     print(json.load(fh)["tag_name"])
@@ -50,14 +81,34 @@ if [ "${#URLS[@]}" -eq 0 ]; then
     exit 1
 fi
 
-cd "$TMPDIR"
+if (( PRINT_ASSETS == 1 )); then
+    echo "linux-xr RT release ${TAG}"
+    printf '%s\n' "${URLS[@]}"
+    exit 0
+fi
+
+if [[ -n "${TARGET_DIR}" ]]; then
+    mkdir -p "${TARGET_DIR}"
+    DOWNLOAD_DIR="$(cd "${TARGET_DIR}" && pwd)"
+elif (( DOWNLOAD_ONLY == 1 )); then
+    DOWNLOAD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/linux-xr-rt.XXXXXX")"
+else
+    DOWNLOAD_DIR="${WORKDIR}"
+fi
+
+cd "$DOWNLOAD_DIR"
 for url in "${URLS[@]}"; do
     curl -fL -O "$url"
 done
 
+if (( DOWNLOAD_ONLY == 1 )); then
+    echo "Downloaded linux-xr RT release ${TAG} to ${DOWNLOAD_DIR}"
+    exit 0
+fi
+
 sudo dnf install -y ./*.rpm
 
-if command -v grubby >/dev/null 2>&1; then
+if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
     kernel_path="$(ls -1 /boot/vmlinuz-*rt*.xr.el10* 2>/dev/null | sort -V | tail -1 || true)"
     if [ -n "${kernel_path:-}" ]; then
         sudo grubby --set-default "$kernel_path" || true


### PR DESCRIPTION
## Summary
- add `--print-assets`, `--download-only`, `--target-dir`, and `--no-set-default` to the public installer scripts
- document those modes in the install docs
- record current `honey` and `yoga` host state in the host docs

## Why
Both `honey` and `yoga` require interactive sudo, so the install surface needs a safe non-root validation and staging path instead of assuming immediate package installation.

## Validation
- `bash -n` on both installer scripts
- `git diff --check`
- verified `--print-assets` locally and over SSH on `yoga`
