### PR TITLE
Fix RT kernel registration and runtime installers

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -30,7 +30,11 @@ on:
 
 jobs:
   build-rpm:
-    runs-on: tinyland-dind
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - tinyland-nix
     container: rockylinux/rockylinux:10
     timeout-minutes: 360
 

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -85,6 +85,15 @@ jobs:
           echo "rt_version=${RT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building kernel ${KVERSION}-${XR_RELEASE}.xr.el10 [${{ matrix.variant.name }}] (RT: ${RT_VERSION:-disabled})"
 
+      - name: Clean stale workspace cache
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/work" \
+            "${BUILD_IMAGE}" \
+            bash -lc 'rm -rf /work/.ccache'
+
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
         uses: actions/checkout@v4
@@ -93,7 +102,7 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         uses: actions/cache/restore@v4
         with:
-          path: ${{ github.workspace }}/.ccache
+          path: ${{ runner.temp }}/linux-xr-ccache-${{ matrix.variant.name }}
           key: ccache-${{ matrix.variant.name }}-${{ steps.version.outputs.kversion }}-${{ hashFiles('xr/config/base.config') }}-${{ github.sha }}
           restore-keys: |
             ccache-${{ matrix.variant.name }}-${{ steps.version.outputs.kversion }}-${{ hashFiles('xr/config/base.config') }}-
@@ -122,11 +131,12 @@ jobs:
           XR_RELEASE: ${{ steps.version.outputs.xr_release }}
           RT_VERSION: ${{ steps.version.outputs.rt_version }}
         run: |
-          mkdir -p "${HOME}/rpmbuild" "${GITHUB_WORKSPACE}/.ccache"
+          CCACHE_DIR_HOST="${RUNNER_TEMP}/linux-xr-ccache-${{ matrix.variant.name }}"
+          mkdir -p "${HOME}/rpmbuild" "${CCACHE_DIR_HOST}"
           docker run --rm --network host \
             -v "${GITHUB_WORKSPACE}:/work" \
             -v "${HOME}/rpmbuild:/root/rpmbuild" \
-            -v "${GITHUB_WORKSPACE}/.ccache:/work/.ccache" \
+            -v "${CCACHE_DIR_HOST}:/work/.ccache" \
             -w /work \
             -e HOME=/root \
             -e GITHUB_WORKSPACE=/work \
@@ -177,7 +187,7 @@ jobs:
         if: always() && steps.filter.outputs.skip != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ${{ github.workspace }}/.ccache
+          path: ${{ runner.temp }}/linux-xr-ccache-${{ matrix.variant.name }}
           key: ccache-${{ matrix.variant.name }}-${{ steps.version.outputs.kversion }}-${{ hashFiles('xr/config/base.config') }}-${{ github.sha }}
 
       - name: Save kernel sources

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -35,8 +35,9 @@ jobs:
       - Linux
       - X64
       - tinyland-nix
-    container: rockylinux/rockylinux:10
     timeout-minutes: 360
+    env:
+      BUILD_IMAGE: rockylinux/rockylinux:10
 
     strategy:
       fail-fast: false
@@ -84,28 +85,6 @@ jobs:
           echo "rt_version=${RT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building kernel ${KVERSION}-${XR_RELEASE}.xr.el10 [${{ matrix.variant.name }}] (RT: ${RT_VERSION:-disabled})"
 
-      - name: Install build dependencies
-        if: steps.filter.outputs.skip != 'true'
-        run: |
-          # Pin dl.rockylinux.org as fallback when mirrorlist is unreachable
-          for repo in /etc/yum.repos.d/rocky*.repo; do
-            sed -i 's|^mirrorlist=|#mirrorlist=|' "$repo"
-            sed -i 's|^#baseurl=http://dl.rockylinux.org|baseurl=https://dl.rockylinux.org|' "$repo"
-          done
-          dnf install -y --setopt=retries=3 epel-release
-          # Re-enable mirrorlist now that epel is installed (better mirror selection)
-          for repo in /etc/yum.repos.d/rocky*.repo; do
-            sed -i 's|^#mirrorlist=|mirrorlist=|' "$repo"
-            sed -i 's|^baseurl=https://dl.rockylinux.org|#baseurl=http://dl.rockylinux.org|' "$repo"
-          done
-          dnf config-manager --set-enabled crb
-          dnf install -y --setopt=retries=3 \
-            gcc make elfutils-libelf-devel openssl-devel openssl \
-            bc bison flex rsync rpm-build dwarves kmod \
-            curl xz patch tar gzip cpio ccache \
-            lld zstd libzstd-devel perl-interpreter \
-            diffutils findutils
-
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
         uses: actions/checkout@v4
@@ -130,34 +109,62 @@ jobs:
             ~/rpmbuild/SOURCES/patch-*-rt*.patch
           key: sources-${{ steps.version.outputs.kversion }}-${{ steps.version.outputs.rt_version }}
 
-      - name: Configure ccache
-        if: steps.filter.outputs.skip != 'true'
-        run: |
-          ccache --set-config=cache_dir=${{ github.workspace }}/.ccache
-          ccache --max-size=8G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --set-config=depend_mode=true
-          ccache --set-config=sloppiness=time_macros,pch_defines
-          ccache -z
-          echo "CC=ccache gcc" >> "$GITHUB_ENV"
-
       - name: Build RPMs
         if: steps.filter.outputs.skip != 'true'
+        env:
+          KVERSION: ${{ steps.version.outputs.kversion }}
+          XR_RELEASE: ${{ steps.version.outputs.xr_release }}
+          RT_VERSION: ${{ steps.version.outputs.rt_version }}
         run: |
-          chmod +x xr/scripts/build-rpm.sh
-          RT_FLAG=""
-          if [[ -n "${{ steps.version.outputs.rt_version }}" ]]; then
-            RT_FLAG="--rt-version ${{ steps.version.outputs.rt_version }}"
-          fi
-          xr/scripts/build-rpm.sh \
-            --kernel-version "${{ steps.version.outputs.kversion }}" \
-            --xr-release "${{ steps.version.outputs.xr_release }}" \
-            ${RT_FLAG}
-
-      - name: Show ccache stats
-        if: always() && steps.filter.outputs.skip != 'true'
-        run: ccache -s
+          mkdir -p "${HOME}/rpmbuild" "${GITHUB_WORKSPACE}/.ccache"
+          docker run --rm --network host \
+            -v "${GITHUB_WORKSPACE}:/work" \
+            -v "${HOME}/rpmbuild:/root/rpmbuild" \
+            -v "${GITHUB_WORKSPACE}/.ccache:/work/.ccache" \
+            -w /work \
+            -e HOME=/root \
+            -e GITHUB_WORKSPACE=/work \
+            -e KVERSION \
+            -e XR_RELEASE \
+            -e RT_VERSION \
+            -e CC="ccache gcc" \
+            "${BUILD_IMAGE}" \
+            bash -lc '
+              set -euo pipefail
+              for repo in /etc/yum.repos.d/rocky*.repo; do
+                sed -i "s|^mirrorlist=|#mirrorlist=|" "$repo"
+                sed -i "s|^#baseurl=http://dl.rockylinux.org|baseurl=https://dl.rockylinux.org|" "$repo"
+              done
+              dnf install -y --setopt=retries=3 epel-release
+              for repo in /etc/yum.repos.d/rocky*.repo; do
+                sed -i "s|^#mirrorlist=|mirrorlist=|" "$repo"
+                sed -i "s|^baseurl=https://dl.rockylinux.org|#baseurl=http://dl.rockylinux.org|" "$repo"
+              done
+              dnf config-manager --set-enabled crb
+              dnf install -y --setopt=retries=3 \
+                gcc make elfutils-libelf-devel openssl-devel openssl \
+                bc bison flex rsync rpm-build dwarves kmod \
+                curl xz patch tar gzip cpio ccache \
+                lld zstd libzstd-devel perl-interpreter \
+                diffutils findutils
+              ccache --set-config=cache_dir=/work/.ccache
+              ccache --max-size=8G
+              ccache --set-config=compression=true
+              ccache --set-config=compression_level=6
+              ccache --set-config=depend_mode=true
+              ccache --set-config=sloppiness=time_macros,pch_defines
+              ccache -z
+              chmod +x xr/scripts/build-rpm.sh
+              RT_FLAG=()
+              if [[ -n "${RT_VERSION}" ]]; then
+                RT_FLAG=(--rt-version "${RT_VERSION}")
+              fi
+              xr/scripts/build-rpm.sh \
+                --kernel-version "${KVERSION}" \
+                --xr-release "${XR_RELEASE}" \
+                "${RT_FLAG[@]}"
+              ccache -s
+            '
 
       # Explicit cache saves — not reliant on post hooks that get killed on cancellation
       - name: Save ccache

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -109,6 +109,12 @@ jobs:
             ~/rpmbuild/SOURCES/patch-*-rt*.patch
           key: sources-${{ steps.version.outputs.kversion }}-${{ steps.version.outputs.rt_version }}
 
+      - name: Clean previous RPM outputs
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          mkdir -p "${HOME}/rpmbuild/RPMS"
+          find "${HOME}/rpmbuild/RPMS" -type f -name 'kernel-xr*.rpm' -delete
+
       - name: Build RPMs
         if: steps.filter.outputs.skip != 'true'
         env:

--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -10,7 +10,8 @@ Current known state from the 2026-04-11 audit:
 
 - running kernel: `6.19.5-5.xr.el10`
 - installed generic XR kernels: `6.19.5-4`, `6.19.5-5`, and `6.19.5-6`
-- installed RT RPMs: present, but not the documented default lane
+- installed RT runtime RPM: `kernel-xr-rt-6.19.5-6.xr.el10`
+- current `v6.19.5-xr6` RT artifacts do not register a BLS entry or initramfs on install; they are not reboot-ready yet
 - OpenXR userspace present
 - Monado unit files present but disabled
 - sudo requires an interactive password on this host
@@ -18,4 +19,4 @@ Current known state from the 2026-04-11 audit:
 Current rollout stance:
 
 - generic XR kernel: active and documented
-- RT XR kernel: still gated pending repeatable boot and latency validation
+- RT XR kernel: still gated pending RPM post-install fix, repeatable boot validation, and latency checks

--- a/site/docs/yoga.md
+++ b/site/docs/yoga.md
@@ -11,10 +11,11 @@ Current known state from the 2026-04-11 audit:
 - running kernel: `6.12.0-124.45.1.el10_1.x86_64`
 - installed kernels are still stock Rocky 10 builds
 - no XR kernel install detected
+- generic XR runtime RPMs are staged in `~/linux-xr-staging/generic`
 - no local `linux-xr` or `XoxdWM` checkout detected in `~/git`
 - sudo requires an interactive password on this host
 
 Current rollout stance:
 
-- next target for generic XR installer validation
+- next target for generic XR runtime install and reboot validation
 - not yet a documented RT target

--- a/site/install.md
+++ b/site/install.md
@@ -11,7 +11,7 @@ curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | 
 curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
 ```
 
-The scripts download the latest release assets, install the matching RPM set, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
+The scripts download the latest release assets, install the runtime kernel RPM by default, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
 
 For non-root validation or staged rollout work, both scripts also support:
 
@@ -19,8 +19,15 @@ For non-root validation or staged rollout work, both scripts also support:
 - `--download-only` to fetch RPMs without installing them
 - `--target-dir <dir>` to control where downloaded RPMs are staged
 - `--no-set-default` to install without changing the default boot entry
+- `--with-devel` to also install the matching `kernel-xr-devel` or `kernel-xr-rt-devel` RPM
+- `--with-headers` to also install the matching `kernel-xr-headers` or `kernel-xr-rt-headers` RPM
 
 ## Variants
 
 - `generic`: default documented rollout lane for Rocky 10 hosts
 - `rt`: gated lane for hosts that have passed the RT boot and latency checklist
+
+## Notes
+
+- The default runtime-only install avoids conflicts with Rocky's stock `kernel-headers` package on existing hosts.
+- The `--with-headers` flag is for development hosts that need UAPI headers and may require removing or replacing the stock `kernel-headers` package first.

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -7,6 +7,8 @@ MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
 DOWNLOAD_ONLY=0
 PRINT_ASSETS=0
 SET_DEFAULT=1
+INSTALL_DEVEL=0
+INSTALL_HEADERS=0
 TARGET_DIR=""
 
 need_cmd() {
@@ -25,6 +27,8 @@ Options:
   --download-only     Download RPMs without installing them
   --target-dir DIR    Directory to place downloaded RPMs in
   --no-set-default    Skip grubby default-kernel update after install
+  --with-devel        Install the matching kernel-xr-devel RPM too
+  --with-headers      Install the matching kernel-xr-headers RPM too
   --help              Show this help
 EOF
 }
@@ -35,6 +39,8 @@ while [[ $# -gt 0 ]]; do
         --download-only) DOWNLOAD_ONLY=1; shift ;;
         --target-dir) TARGET_DIR="$2"; shift 2 ;;
         --no-set-default) SET_DEFAULT=0; shift ;;
+        --with-devel) INSTALL_DEVEL=1; shift ;;
+        --with-headers) INSTALL_HEADERS=1; shift ;;
         --help) usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
@@ -108,7 +114,28 @@ if (( DOWNLOAD_ONLY == 1 )); then
     exit 0
 fi
 
-sudo dnf install -y ./*.rpm
+mapfile -t INSTALL_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-[0-9]*.rpm' | sort)
+
+if (( INSTALL_DEVEL == 1 )); then
+    mapfile -t DEVEL_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-devel-*.rpm' | sort)
+    INSTALL_RPMS+=("${DEVEL_RPMS[@]}")
+fi
+
+if (( INSTALL_HEADERS == 1 )); then
+    mapfile -t HEADER_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-headers-*.rpm' | sort)
+    INSTALL_RPMS+=("${HEADER_RPMS[@]}")
+fi
+
+if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
+    echo "No installable generic RPMs found in ${DOWNLOAD_DIR}." >&2
+    exit 1
+fi
+
+echo "Installing runtime kernel package(s) from ${DOWNLOAD_DIR}."
+if (( INSTALL_DEVEL == 1 || INSTALL_HEADERS == 1 )); then
+    echo "Optional development/header packages requested."
+fi
+sudo dnf install -y "${INSTALL_RPMS[@]}"
 
 if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
     kernel_path="$(ls -1 /boot/vmlinuz-*xr.el10* 2>/dev/null | grep -v 'rt' | sort -V | tail -1 || true)"

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -7,6 +7,8 @@ MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
 DOWNLOAD_ONLY=0
 PRINT_ASSETS=0
 SET_DEFAULT=1
+INSTALL_DEVEL=0
+INSTALL_HEADERS=0
 TARGET_DIR=""
 
 need_cmd() {
@@ -25,6 +27,8 @@ Options:
   --download-only     Download RPMs without installing them
   --target-dir DIR    Directory to place downloaded RPMs in
   --no-set-default    Skip grubby default-kernel update after install
+  --with-devel        Install the matching kernel-xr-rt-devel RPM too
+  --with-headers      Install the matching kernel-xr-rt-headers RPM too
   --help              Show this help
 EOF
 }
@@ -35,6 +39,8 @@ while [[ $# -gt 0 ]]; do
         --download-only) DOWNLOAD_ONLY=1; shift ;;
         --target-dir) TARGET_DIR="$2"; shift 2 ;;
         --no-set-default) SET_DEFAULT=0; shift ;;
+        --with-devel) INSTALL_DEVEL=1; shift ;;
+        --with-headers) INSTALL_HEADERS=1; shift ;;
         --help) usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
@@ -106,7 +112,28 @@ if (( DOWNLOAD_ONLY == 1 )); then
     exit 0
 fi
 
-sudo dnf install -y ./*.rpm
+mapfile -t INSTALL_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-rt-[0-9]*.rpm' | sort)
+
+if (( INSTALL_DEVEL == 1 )); then
+    mapfile -t DEVEL_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-rt-devel-*.rpm' | sort)
+    INSTALL_RPMS+=("${DEVEL_RPMS[@]}")
+fi
+
+if (( INSTALL_HEADERS == 1 )); then
+    mapfile -t HEADER_RPMS < <(find . -maxdepth 1 -type f -name 'kernel-xr-rt-headers-*.rpm' | sort)
+    INSTALL_RPMS+=("${HEADER_RPMS[@]}")
+fi
+
+if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
+    echo "No installable RT RPMs found in ${DOWNLOAD_DIR}." >&2
+    exit 1
+fi
+
+echo "Installing runtime kernel package(s) from ${DOWNLOAD_DIR}."
+if (( INSTALL_DEVEL == 1 || INSTALL_HEADERS == 1 )); then
+    echo "Optional development/header packages requested."
+fi
+sudo dnf install -y "${INSTALL_RPMS[@]}"
 
 if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
     kernel_path="$(ls -1 /boot/vmlinuz-*rt*.xr.el10* 2>/dev/null | sort -V | tail -1 || true)"

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -18,6 +18,11 @@
 %global krelease  %{xr_release}.xr.el10
 %{!?rt_version: %global rt_version %{nil}}
 %{!?variant: %global variant %{nil}}
+%if "%{variant}" == "-rt"
+%global actual_krel_regex ^%{kversion}-rt[^[:space:]]*-%{krelease}$
+%else
+%global actual_krel_regex ^%{kversion}-%{krelease}$
+%endif
 
 Name:           kernel-xr%{variant}
 Version:        %{kversion}
@@ -275,7 +280,7 @@ ln -sf /usr/src/kernels/${KREL} \
 %post
 # Phase 1: signal that core is being installed (modules may arrive later)
 KREL=%{kversion}-%{krelease}
-ACTUAL_KREL=$(ls /lib/modules/ | grep "%{kversion}.*%{krelease}" | head -1)
+ACTUAL_KREL=$(ls /lib/modules/ | grep -E '%{actual_krel_regex}' | sort -V | tail -1)
 mkdir -p /var/lib/rpm-state/kernel
 touch /var/lib/rpm-state/kernel/installing_core_${ACTUAL_KREL:-${KREL}}
 
@@ -283,7 +288,7 @@ touch /var/lib/rpm-state/kernel/installing_core_${ACTUAL_KREL:-${KREL}}
 # Phase 2: runs after ALL sub-packages in the transaction are installed.
 # This is the canonical point for kernel-install (triggers depmod, dracut, BLS).
 KREL=%{kversion}-%{krelease}
-ACTUAL_KREL=$(ls /lib/modules/ | grep "%{kversion}.*%{krelease}" | head -1)
+ACTUAL_KREL=$(ls /lib/modules/ | grep -E '%{actual_krel_regex}' | sort -V | tail -1)
 ACTUAL_KREL=${ACTUAL_KREL:-${KREL}}
 
 # Remove installing flag
@@ -316,7 +321,7 @@ echo "Validate: sudo smi-validate --full"
 
 %preun
 KREL=%{kversion}-%{krelease}
-ACTUAL_KREL=$(ls /lib/modules/ | grep "%{kversion}.*%{krelease}" | head -1)
+ACTUAL_KREL=$(ls /lib/modules/ | grep -E '%{actual_krel_regex}' | sort -V | tail -1)
 ACTUAL_KREL=${ACTUAL_KREL:-${KREL}}
 if [ -x /usr/bin/kernel-install ]; then
     /usr/bin/kernel-install remove ${ACTUAL_KREL} || exit $?


### PR DESCRIPTION
## Summary
- match the actual RT kernel release string precisely in RPM scriptlets so posttrans registers the RT kernel instead of the generic one
- make the public Rocky 10 installers install the runtime kernel by default, with optional devel and headers flags
- document the current honey RT packaging findings and staged yoga rollout state

## Validation
- bash -n site/install/rocky10-generic.sh
- bash -n site/install/rocky10-rt.sh
- git diff --check
- verified runtime-only RPM selection patterns under bash
- live host findings on honey: current RT runtime RPM installs files and modules but misses BLS and initramfs because the generic KREL wins the old scriptlet match
