### PR TITLE
Publish Pages on release publication

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger the Pages workflow when a GitHub release is published
- keep the existing xr/main site-change trigger and manual dispatch path

## Why
The site generates  from the latest GitHub release. Without a release trigger, publishing a new kernel release leaves the public install surface stale until Pages is rerun manually.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml")'
- git diff --check