### PR TITLE
Honor no-set-default in installers

### DIFF
--- a/site/install.md
+++ b/site/install.md
@@ -20,7 +20,7 @@ For non-root validation or staged rollout work, both scripts also support:
 - `--print-assets` to show the selected release and RPM URLs without downloading
 - `--download-only` to fetch RPMs without installing them
 - `--target-dir <dir>` to control where downloaded RPMs are staged
-- `--no-set-default` to install without changing the default boot entry
+- `--no-set-default` to install without leaving the new kernel as the default boot entry
 - `--with-devel` to also install the matching `kernel-xr-devel` or `kernel-xr-rt-devel` RPM
 - `--with-headers` to also install the matching `kernel-xr-headers` or `kernel-xr-rt-headers` RPM
 
@@ -32,4 +32,5 @@ For non-root validation or staged rollout work, both scripts also support:
 ## Notes
 
 - The default runtime-only install avoids conflicts with Rocky's stock `kernel-headers` package on existing hosts.
+- `--no-set-default` captures the current default kernel and restores it after install if the package scriptlets change it.
 - The `--with-headers` flag is for development hosts that need UAPI headers and may require removing or replacing the stock `kernel-headers` package first.

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -131,16 +131,29 @@ if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
     exit 1
 fi
 
+ORIGINAL_DEFAULT=""
+if (( SET_DEFAULT == 0 )) && command -v grubby >/dev/null 2>&1; then
+    ORIGINAL_DEFAULT="$(sudo grubby --default-kernel 2>/dev/null || true)"
+fi
+
 echo "Installing runtime kernel package(s) from ${DOWNLOAD_DIR}."
 if (( INSTALL_DEVEL == 1 || INSTALL_HEADERS == 1 )); then
     echo "Optional development/header packages requested."
 fi
 sudo dnf install -y "${INSTALL_RPMS[@]}"
 
-if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
-    kernel_path="$(ls -1 /boot/vmlinuz-*xr.el10* 2>/dev/null | grep -v 'rt' | sort -V | tail -1 || true)"
-    if [ -n "${kernel_path:-}" ]; then
-        sudo grubby --set-default "$kernel_path" || true
+if command -v grubby >/dev/null 2>&1; then
+    if (( SET_DEFAULT == 1 )); then
+        kernel_path="$(ls -1 /boot/vmlinuz-*xr.el10* 2>/dev/null | grep -v 'rt' | sort -V | tail -1 || true)"
+        if [ -n "${kernel_path:-}" ]; then
+            sudo grubby --set-default "$kernel_path" || true
+        fi
+    elif [ -n "${ORIGINAL_DEFAULT}" ]; then
+        current_default="$(sudo grubby --default-kernel 2>/dev/null || true)"
+        if [ -n "${current_default}" ] && [ "${current_default}" != "${ORIGINAL_DEFAULT}" ]; then
+            echo "Restoring previous default boot entry: ${ORIGINAL_DEFAULT}"
+            sudo grubby --set-default "${ORIGINAL_DEFAULT}" || true
+        fi
     fi
 fi
 

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -129,16 +129,29 @@ if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
     exit 1
 fi
 
+ORIGINAL_DEFAULT=""
+if (( SET_DEFAULT == 0 )) && command -v grubby >/dev/null 2>&1; then
+    ORIGINAL_DEFAULT="$(sudo grubby --default-kernel 2>/dev/null || true)"
+fi
+
 echo "Installing runtime kernel package(s) from ${DOWNLOAD_DIR}."
 if (( INSTALL_DEVEL == 1 || INSTALL_HEADERS == 1 )); then
     echo "Optional development/header packages requested."
 fi
 sudo dnf install -y "${INSTALL_RPMS[@]}"
 
-if (( SET_DEFAULT == 1 )) && command -v grubby >/dev/null 2>&1; then
-    kernel_path="$(ls -1 /boot/vmlinuz-*rt*.xr.el10* 2>/dev/null | sort -V | tail -1 || true)"
-    if [ -n "${kernel_path:-}" ]; then
-        sudo grubby --set-default "$kernel_path" || true
+if command -v grubby >/dev/null 2>&1; then
+    if (( SET_DEFAULT == 1 )); then
+        kernel_path="$(ls -1 /boot/vmlinuz-*rt*.xr.el10* 2>/dev/null | sort -V | tail -1 || true)"
+        if [ -n "${kernel_path:-}" ]; then
+            sudo grubby --set-default "$kernel_path" || true
+        fi
+    elif [ -n "${ORIGINAL_DEFAULT}" ]; then
+        current_default="$(sudo grubby --default-kernel 2>/dev/null || true)"
+        if [ -n "${current_default}" ] && [ "${current_default}" != "${ORIGINAL_DEFAULT}" ]; then
+            echo "Restoring previous default boot entry: ${ORIGINAL_DEFAULT}"
+            sudo grubby --set-default "${ORIGINAL_DEFAULT}" || true
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
- preserve the pre-install default boot entry when --no-set-default is used
- restore that default after install if the RPM scriptlets changed it
- document the behavior in the public install docs

## Validation
- bash -n site/install/rocky10-generic.sh
- bash -n site/install/rocky10-rt.sh
- git diff --check
- live host validation on honey and yoga showed generic installs could otherwise move the default kernel unexpectedly
