### PR TITLE
Validate RT preemption config

### DIFF
--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -199,6 +199,8 @@ check_config() {
             echo "  OK: ${key} is not set"
         elif echo "$actual" | grep -q "=n"; then
             echo "  OK: ${key}=n"
+        elif [ "$actual" = "MISSING" ]; then
+            echo "  OK: ${key} is absent"
         else
             echo "  FAIL: ${key} should be disabled but got: ${actual}"
             fail=1

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -138,6 +138,10 @@ scripts/config --enable CONFIG_UIO_PCI_GENERIC
 
 # RT-specific config
 %if "%{rt_version}" != ""
+# Linux 6.19's PREEMPT_RT Kconfig depends on CONFIG_EXPERT. Without this,
+# the build can retain the -rt kernelrelease while silently falling back to
+# a non-RT preemption model.
+scripts/config --enable CONFIG_EXPERT
 scripts/config --enable CONFIG_PREEMPT_RT
 scripts/config --disable CONFIG_PREEMPT_VOLUNTARY
 scripts/config --disable CONFIG_PREEMPT_NONE
@@ -214,6 +218,12 @@ check_config CONFIG_DEBUG_INFO_NONE n
 check_config CONFIG_DEBUG_INFO_REDUCED n
 check_config CONFIG_BPF_SYSCALL y
 check_config CONFIG_CGROUP_BPF y
+%if "%{rt_version}" != ""
+check_config CONFIG_EXPERT y
+check_config CONFIG_PREEMPT_RT y
+check_config CONFIG_PREEMPT_NONE n
+check_config CONFIG_PREEMPT_VOLUNTARY n
+%endif
 if [ "$fail" -ne 0 ]; then
     echo "FATAL: Critical kernel config validation failed. Aborting build."
     echo "This kernel would fail to boot on systemd 257 (Rocky 10.1)."


### PR DESCRIPTION
## Summary
- enable CONFIG_EXPERT for RT builds so Linux 6.19 allows CONFIG_PREEMPT_RT to stick
- hard-fail the build if an RT-labeled package does not actually resolve to PREEMPT_RT
- prevent future release tags from shipping non-RT kernels under RT naming

## Validation
- git diff --check
- live host validation on honey showed the existing RT-labeled kernel booted with CONFIG_PREEMPT_NONE and no CONFIG_PREEMPT_RT
- config-only reproduction on honey with the 6.19 RT patch and the same base config resolved to CONFIG_PREEMPT_RT=y once CONFIG_EXPERT was enabled
