### PR TITLE
Add thin Nix and Determinate CI surface

### DIFF
--- a/.github/workflows/determinate-ci.yml
+++ b/.github/workflows/determinate-ci.yml
@@ -1,0 +1,20 @@
+name: Determinate CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - xr/main
+
+jobs:
+  determinate-ci:
+    # This caches and validates the thin Nix surface for linux-xr. It is not
+    # the canonical kernel RPM release lane, which remains the Rocky/Linux
+    # workflow in build-kernel.yml.
+    uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      visibility: unlisted

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ As of 2026-04-11:
 - RT installer: `https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh`
 - Carry patches: [`xr/patches`](xr/patches)
 
+## Nix / FlakeHub
+
+This repo now carries a thin flake surface in [`flake.nix`](flake.nix) for
+developer tooling and cacheable checks. It is intentionally not the canonical
+kernel release build.
+
+- `nix develop` provides a shell with the core patch/report tooling.
+- `nix flake check` validates the patch series and shell-script syntax.
+- `nix run .#cadence-report -- --upstream-ref <ref> --stable-ref <ref>` runs the weekly cadence report helper from a repo checkout.
+- `.github/workflows/determinate-ci.yml` pushes those lightweight flake outputs through Determinate CI / FlakeHub Cache.
+
+The real RPM release lane remains [`build-kernel.yml`](.github/workflows/build-kernel.yml) plus [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh) on Linux. Modeling the full kernel RPM build itself as a flake output is a separate, larger piece of work that should stay explicitly tracked.
+
 ## What's patched
 
 | Patch | Purpose |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,121 @@
+{
+  description = "Thin Nix surface for linux-xr developer tooling and CI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = f:
+        builtins.listToAttrs (map (system: {
+          name = system;
+          value = f system;
+        }) systems);
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages =
+              (with pkgs; [
+                bashInteractive
+                ccache
+                coreutils
+                curl
+                cpio
+                diffutils
+                findutils
+                gawk
+                git
+                gnugrep
+                gnused
+                gnutar
+                gzip
+                jq
+                patch
+                ripgrep
+                xz
+              ])
+              ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                pkgs.rpm
+              ];
+
+            shellHook = ''
+              echo "linux-xr dev shell"
+              echo "  - nix flake check          # validate thin flake outputs"
+              echo "  - ./xr/scripts/build-rpm.sh # canonical Linux/RPM build path"
+            '';
+          };
+        });
+
+      checks = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          patch-series = pkgs.runCommand "linux-xr-patch-series-check" {
+            nativeBuildInputs = with pkgs; [ bash coreutils gnugrep ];
+          } ''
+            set -euo pipefail
+            patch_dir="${self}/xr/patches"
+            series_file="$patch_dir/series"
+
+            test -f "$series_file"
+
+            while IFS= read -r patch; do
+              case "$patch" in
+                ""|\#*)
+                  continue
+                  ;;
+              esac
+
+              test -f "$patch_dir/$patch"
+            done < "$series_file"
+
+            mkdir -p "$out"
+          '';
+
+          shell-syntax = pkgs.runCommand "linux-xr-shell-syntax-check" {
+            nativeBuildInputs = with pkgs; [ bash coreutils ];
+          } ''
+            set -euo pipefail
+            bash -n "${self}/xr/scripts/build-rpm.sh"
+            bash -n "${self}/xr/scripts/generate-cadence-report.sh"
+            mkdir -p "$out"
+          '';
+        });
+
+      apps = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          cadenceReport = pkgs.writeShellApplication {
+            name = "linux-xr-cadence-report";
+            runtimeInputs = with pkgs; [ bash git coreutils gnugrep gnused ];
+            text = ''
+              set -euo pipefail
+              repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+              exec "$repo_root/xr/scripts/generate-cadence-report.sh" "$@"
+            '';
+          };
+        in
+        {
+          cadence-report = {
+            type = "app";
+            program = "${cadenceReport}/bin/linux-xr-cadence-report";
+          };
+        });
+
+      formatter = forAllSystems (system:
+        (import nixpkgs { inherit system; }).nixfmt-rfc-style);
+    };
+}


### PR DESCRIPTION
## Summary
- add a thin `flake.nix` surface for developer tooling, lightweight checks, and cacheable Determinate CI outputs
- add a Determinate CI workflow for FlakeHub Cache on the Nix surface without disturbing the canonical Rocky RPM release lane
- document the immediate scope and explicitly track the future larger lift of modeling the kernel RPM build itself as a flake output

## Validation
- `nix flake show /Users/jess/git/linux-xr-fast`
- `nix flake check /Users/jess/git/linux-xr-fast`
- `git diff --check`

## Follow-on
- future full-kernel flake work tracked in #18
