### PR TITLE
Stabilize linux-xr carry hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Fork of `torvalds/linux` with CI-built RPMs carrying VR/XR patches.
 
 ## Current State
 
-As of 2026-04-11:
+As of 2026-04-25:
 
 | Area | Status | Notes |
 | --- | --- | --- |
 | Release artifacts | Proven | Latest public release ships generic and RT RPMs. |
-| `honey` rollout | Proven (generic) | `honey` is currently running `6.19.5-5.xr.el10`. |
-| `honey` RT default boot | Gated | RT artifacts exist, but RT is not yet the default documented lane. |
-| `yoga` rollout | Pending | `yoga` is still on the stock Rocky 10 kernel. |
-| Install surface | In progress | GitHub Pages and stable installer paths live in `site/`. |
+| `honey` rollout | Proven (generic) | `honey` is persistently defaulted to the generic XR kernel lane. |
+| `honey` RT boot | Reboot-valid, gated | One-time RT boot and `/sys/kernel/realtime=1` verification succeeded; regular use still needs latency and XR smoke. |
+| `yoga` rollout | Proven one-time generic boot | Generic XR RPM install and one-time boot succeeded; stock Rocky remains the persistent fallback. |
+| Install surface | Active | GitHub Pages and stable installer paths live in `site/`. |
 | Patch carry set | Localized | Kernel-owned carry patches live under `xr/patches/`. |
+| Local checkout requirement | Case-sensitive | Linux source checkouts must be on Linux or a case-sensitive filesystem; macOS case-insensitive checkouts corrupt case-distinct kernel paths. |
 
 ## Public Surfaces
 
@@ -277,6 +278,8 @@ ssh jess@honey "cat /boot/config-$(uname -r)" > xr/config/base.config
   --rt-version 6.19.3-rt1
 ```
 
+Use a Linux or case-sensitive checkout for source truth. On macOS, do not treat a default case-insensitive checkout as authoritative for kernel files because Linux carries case-distinct paths such as `xt_DSCP.c` and `xt_dscp.c`.
+
 ## CI
 
 Tag push (`v6.19.5-xr2`) or manual dispatch triggers RPM builds on
@@ -305,7 +308,7 @@ Build optimizations:
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`
-2. Merge or rebase onto the latest upstream Linux commit that still keeps the carry set clean
+2. Compare against current upstream and stable refs before choosing a merge target
 3. Update `xr/config/base.config` if `honey`'s running base kernel changes
 4. Tag: `git tag -a v6.20.1-xr1 -m "XR kernel 6.20.1"`
 5. CI builds + publishes RPMs
@@ -313,11 +316,14 @@ Build optimizations:
 
 ## Upstream status
 
-| Patch | Upstream status | ETA |
+As of 2026-04-25, `xr/main` is on `55f63ebff7df`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `27d128c1cff6`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
+
+| Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| VESA DisplayID DSC BPP (Bolyukin v7) | Reviewed, NOT merged — missed 7.0 window | ~7.1 (June 2026) |
-| QP table + RC offset (raika-xino) | Never submitted | Needs amd-gfx submission |
-| EDID non_desktop quirk (BIG/0x1234) | Not submitted | Submit to drm-misc |
-| PREEMPT_RT | Mainline since 6.12 | N/A |
+| VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin fixed-DSC-BPP series and drop this part when it lands. |
+| QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry and decide whether this is evidence-backed upstream material or host-only risk. |
+| EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Submit as a small drm-edid/drm-misc candidate after local validation. |
+| SMI and NUMA posture | Platform/runtime validation, not a linux-xr source patch | Keep kernel config support here; keep validators, tuned profiles, and host captures in Dell-7810/XoxdWM surfaces. |
+| PREEMPT_RT | Mainline since 6.12; this repo still downloads RT patches for the configured 6.19.x RT build lane | Re-evaluate when the RPM lane moves to a kernel whose RT posture is fully mainline for our target release. |
 
 Carry patch order is defined in `xr/patches/series`.

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,15 @@
             bash -n "${self}/xr/scripts/generate-cadence-report.sh"
             mkdir -p "$out"
           '';
+
+          patch-application = pkgs.runCommand "linux-xr-patch-application-check" {
+            nativeBuildInputs = with pkgs; [ bash patch ];
+          } ''
+            set -euo pipefail
+            patch -d "${self}" -p1 --dry-run < "${self}/xr/patches/0007-vesa-dsc-bpp.patch"
+            patch -d "${self}" -p1 --dry-run < "${self}/xr/patches/bigscreen-beyond-edid.patch"
+            mkdir -p "$out"
+          '';
         });
 
       apps = forAllSystems (system:
@@ -104,7 +113,7 @@
             text = ''
               set -euo pipefail
               repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-              exec "$repo_root/xr/scripts/generate-cadence-report.sh" "$@"
+              exec bash "$repo_root/xr/scripts/generate-cadence-report.sh" "$@"
             '';
           };
         in

--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -6,7 +6,7 @@ title: honey
 
 Role: primary XR validation host.
 
-Current known state from the 2026-04-12 rollout:
+Historical rollout evidence from the 2026-04-12 validation:
 
 - running kernel: `6.19.5-7.xr.el10`
 - saved default boot kernel: `/boot/vmlinuz-6.19.5-7.xr.el10`
@@ -20,7 +20,13 @@ Current known state from the 2026-04-12 rollout:
 - DRM nodes present on both the generic and RT validation boots
 - sudo requires an interactive password on this host
 
-Current rollout stance:
+Current live host posture is not owned by this page. Dell-7810 is the authority
+for `honey`'s current booted kernel, BIOS/SMI state, tuned profile, and reset
+evidence. Treat the RT bullets above as historical smoke evidence, not as a
+claim that `honey` is currently running RT or has a validated low-latency
+posture.
+
+Rollout stance:
 
 - generic XR kernel: active, documented, and the persistent default
-- RT XR kernel: reboot-valid and functionally verified, but still gated for regular use pending latency tooling and deeper XR smoke
+- RT XR kernel: one-time reboot-valid and functionally verified, but still gated for regular use pending latency tooling and deeper XR smoke

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -4,7 +4,7 @@ title: Upstream Status
 
 # Upstream Status
 
-Baseline date: 2026-04-11
+Baseline date: 2026-04-25
 
 ## Carry Set
 
@@ -12,10 +12,29 @@ Carry order is defined in `xr/patches/series`.
 
 - `xr/patches/0007-vesa-dsc-bpp.patch`
   - state: carry
-  - reason: DSC fixed-BPP parsing/passthrough work remains unmerged upstream
+  - reason: DSC fixed-BPP parsing/passthrough work remains absent from the current upstream checkout
+  - reduction path: split the in-flight DisplayID/amdgpu series from local QP table and RC offset adjustments
 - `xr/patches/bigscreen-beyond-edid.patch`
   - state: upstream candidate
-  - reason: Bigscreen Beyond non-desktop quirk still absent from upstream `drm_edid.c`
+  - reason: Bigscreen Beyond non-desktop quirk remains absent from upstream `drm_edid.c`
+
+## Current Upstream Snapshot
+
+- linux-xr `xr/main`: `55f63ebff7df`
+- upstream `master` observed from kernel.org: `27d128c1cff6`
+- latest upstream tag observed locally: `v7.0`
+- latest `6.19.y` stable tag observed locally: `v6.19.14`
+
+The current RPM lane still builds the configured `6.19.5` tarball. Moving the
+release lane forward should be a deliberate cadence item, not an incidental
+merge.
+
+## Boundary Notes
+
+SMI, NUMA, and tuned-profile work are platform/runtime validation surfaces.
+linux-xr should keep kernel config support for those lanes, but host validators,
+tuned profiles, captures, and rollback procedures belong in Dell-7810 and
+XoxdWM operator surfaces.
 
 ## Kernel Cadence
 

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -6,7 +6,7 @@ Patch application order is defined in `series`.
 
 Current carry classification:
 
-- `0007-vesa-dsc-bpp.patch`: carry while the DSC fixed-BPP series remains unmerged upstream
-- `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk
+- `0007-vesa-dsc-bpp.patch`: carry while the DSC fixed-BPP path remains absent upstream; split upstream-tracked DisplayID/amdgpu work from local QP/RC offset adjustments before submission.
+- `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk.
 
 The build and release workflows should source patches from here rather than another repo.

--- a/xr/patches/bigscreen-beyond-edid.patch
+++ b/xr/patches/bigscreen-beyond-edid.patch
@@ -12,20 +12,26 @@ EDID manufacturer code: "BIG" (PnP ID 0x0927)
 Ref: https://www.phoronix.com/news/Linux-Bigscreen-Beyond-VR
 Ref: https://www.mail-archive.com/dri-devel@lists.freedesktop.org/msg493878.html
 ---
- drivers/gpu/drm/drm_edid.c | 4 ++++
- 1 file changed, 4 insertions(+)
+ drivers/gpu/drm/drm_edid.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
-index XXXXXXX..YYYYYYY 100644
 --- a/drivers/gpu/drm/drm_edid.c
 +++ b/drivers/gpu/drm/drm_edid.c
-@@ -194,6 +194,10 @@ static const struct edid_quirk {
- 	/* AUO laptop panel produces high CRC errors */
- 	EDID_QUIRK('A', 'U', 'O', 0x305c, EDID_QUIRK_FORCE_10BPC),
-
+@@ -220,6 +220,10 @@ static const struct edid_quirk {
+-	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
+-	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
+-
++	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
++
 +	/* Bigscreen Beyond VR Headsets */
 +	EDID_QUIRK('B', 'I', 'G', 0x1234, BIT(EDID_QUIRK_NON_DESKTOP)),
 +	EDID_QUIRK('B', 'I', 'G', 0x5095, BIT(EDID_QUIRK_NON_DESKTOP)),
 +
- 	/* BOE model on HP Pavilion 15-n233sl */
- 	EDID_QUIRK('B', 'O', 'E', 0x0786, EDID_QUIRK_NO_EDID_QUIRK_FORCE_6BPC),
+-	/* HTC Vive and Vive Pro VR Headsets */
+-	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
+-	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),
++	/* HTC Vive and Vive Pro VR Headsets */
++	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -326,10 +326,10 @@ fi
 echo ""
 echo "kernel-xr installed: ${ACTUAL_KREL}"
 echo ""
-echo "For RT/BCI workloads, install the xr-bci tuned profile:"
-echo "  sudo tuned-adm profile xr-bci"
-echo "  sudo reboot"
-echo "Validate: sudo smi-validate --full"
+echo "For RT/BCI workloads, run the Dell-7810/XoxdWM platform validation lane:"
+echo "  - confirm the intended tuned profile is installed and active"
+echo "  - run the repo-owned SMI/latency validator on the target host"
+echo "  - reboot only through the host runbook's rollback-safe path"
 
 %preun
 KREL=%{kversion}-%{krelease}


### PR DESCRIPTION
## Summary

- repair the Bigscreen Beyond EDID carry patch so the build-time patch tool can dry-run it cleanly
- add a thin Nix patch-application check and make the cadence app invoke its script through bash
- refresh README/site upstream state and clarify SMI/NUMA/tuned ownership boundaries
- clarify that `site/docs/honey.md` records historical April 12 rollout evidence, not current live RT posture
- remove misleading RPM post-install commands for tools that are owned by Dell-7810/XoxdWM rather than linux-xr

## Validation

- `patch -p1 --dry-run < xr/patches/0007-vesa-dsc-bpp.patch`
- `patch -p1 --dry-run < xr/patches/bigscreen-beyond-edid.patch`
- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh site/install/rocky10-generic.sh site/install/rocky10-rt.sh`
- Ruby YAML parse for workflows, issue templates, site docs, and site config
- `git diff --check`
- local aarch64-darwin Nix patch-series, shell-syntax, and patch-application checks with remote builders disabled
- local `nix run .#cadence-report` against `upstream/master` and `v6.19.14` with remote builders disabled

## Tracking

Linear: TIN-559
Issues: #9, #21, #22