### PR TITLE
Document honey host authority boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ applies PREEMPT_RT for deterministic scheduling.
 
 Order of operations for first kernel deployment on a Dell T7810:
 
+This checklist is supplier-side bootstrap guidance for the kernel package. It
+does not replace the current Dell workstation validation ledger. Current BIOS,
+SMI, C-state, PREEMPT_RT acceptance, NUMA, and rollback evidence for `honey`
+lives in `Jesssullivan/Dell-7810`; this repo should only claim package
+availability, install flow, and kernel carry status.
+
 ### Phase 0: Host preflight
 
 - [ ] Confirm the Dell-owned host runbook says the target is ready for this

--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -6,7 +6,22 @@ title: honey
 
 Role: primary XR validation host.
 
+This page owns shipped-kernel rollout context and downstream-consumer framing.
+It does not own the current Dell workstation validation ledger for `honey`.
+
+Use the companion `Dell-7810` repo for the current host-side RT claim ladder:
+
+- C1: RT boot proved
+- C2: RT host posture validated
+- C3: RT operational acceptability
+
+This repo owns C0 supplier facts: the generic and RT kernel RPMs, install
+surface, carry patch set, and release cadence. It does not own SMI, NUMA,
+Chapel, C-state, reset, or workstation acceptance evidence.
+
 Historical rollout evidence from the 2026-04-12 validation:
+
+Current known supplier-side state:
 
 - running kernel: `6.19.5-7.xr.el10`
 - saved default boot kernel: `/boot/vmlinuz-6.19.5-7.xr.el10`
@@ -30,3 +45,9 @@ Rollout stance:
 
 - generic XR kernel: active, documented, and the persistent default
 - RT XR kernel: one-time reboot-valid and functionally verified, but still gated for regular use pending latency tooling and deeper XR smoke
+
+For live `honey` host state and current RT acceptance, see:
+
+- <https://github.com/Jesssullivan/Dell-7810/blob/main/docs/platform/rt-research-contract.md>
+- <https://github.com/Jesssullivan/Dell-7810/blob/main/docs/platform/honey-rt-validation-2026-04-23.md>
+- <https://github.com/Jesssullivan/Dell-7810/blob/main/docs/tracking/rt-smi-numa-chapel-focus-2026-04-25.md>


### PR DESCRIPTION
## Summary

Document the boundary between `linux-xr` supplier facts and Dell-owned `honey` host acceptance evidence.

## Changes

- Clarify that the T7810 deployment checklist is supplier-side bootstrap guidance, not the live Dell validation ledger.
- State that `linux-xr` owns C0 package/release/install facts for `honey`.
- Link `honey` readers to Dell-7810 RT/SMI/NUMA/Chapel authority docs for C1/C2/C3 and workstation acceptance claims.

## Validation

- `nix flake check --no-build`
- `git diff --check`
