### PR TITLE
Refresh DSC upstream status

### DIFF
--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -11,9 +11,12 @@ Baseline date: 2026-04-25
 Carry order is defined in `xr/patches/series`.
 
 - `xr/patches/0007-vesa-dsc-bpp.patch`
-  - state: carry
-  - reason: DSC fixed-BPP parsing/passthrough work remains absent from the current upstream checkout
-  - reduction path: split the in-flight DisplayID/amdgpu series from local QP table and RC offset adjustments
+  - state: carry with partial upstream overlap
+  - reason: current upstream has AMD DSC passthrough plumbing, but the DisplayID
+    VESA fixed-BPP parser and DRM connector/mode propagation carried here remain
+    absent from the current upstream checkout
+  - reduction path: split the DisplayID/parser/connector path from local QP
+    table and RC offset adjustments before deciding what still needs submission
 - `xr/patches/bigscreen-beyond-edid.patch`
   - state: upstream candidate
   - reason: Bigscreen Beyond non-desktop quirk remains absent from upstream `drm_edid.c`
@@ -21,7 +24,7 @@ Carry order is defined in `xr/patches/series`.
 ## Current Upstream Snapshot
 
 - linux-xr `xr/main`: `55f63ebff7df`
-- upstream `master` observed from kernel.org: `27d128c1cff6`
+- upstream `master` observed from kernel.org: `897d54018cc9`
 - latest upstream tag observed locally: `v7.0`
 - latest `6.19.y` stable tag observed locally: `v6.19.14`
 
@@ -35,6 +38,15 @@ SMI, NUMA, and tuned-profile work are platform/runtime validation surfaces.
 linux-xr should keep kernel config support for those lanes, but host validators,
 tuned profiles, captures, and rollback procedures belong in Dell-7810 and
 XoxdWM operator surfaces.
+
+The current DSC carry should not be summarized as "wholly absent upstream."
+After refreshing `upstream/master` on 2026-04-25, upstream already contains
+AMD-side DSC passthrough fields such as `dsc_fixed_bits_per_pixel_x16` and
+`is_dsc_passthrough_supported`. What still appears absent in the checked
+upstream tree is this carry's DisplayID VESA DSC BPP parser and the public DRM
+connector/mode propagation names `dp_dsc_bpp_x16`,
+`DISPLAYID_VESA_DSC_BPP_*`, and `dsc_passthrough_timings_support`. Keep QP/RC
+table changes separate until measured evidence justifies them.
 
 ## Kernel Cadence
 

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -6,7 +6,7 @@ Patch application order is defined in `series`.
 
 Current carry classification:
 
-- `0007-vesa-dsc-bpp.patch`: carry while the DSC fixed-BPP path remains absent upstream; split upstream-tracked DisplayID/amdgpu work from local QP/RC offset adjustments before submission.
+- `0007-vesa-dsc-bpp.patch`: carry with partial upstream overlap; upstream has AMD DSC passthrough plumbing, but this tree still carries the DisplayID/VESA DSC fixed-BPP parser and DRM connector/mode propagation path. Split that parser/connector path from local QP/RC offset adjustments before submission.
 - `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk.
 
 The build and release workflows should source patches from here rather than another repo.


### PR DESCRIPTION
## Summary

Refreshes the DSC carry status after fetching current kernel.org `upstream/master`.

The important correction is that the linux-xr DSC carry is no longer accurately summarized as wholly absent upstream: AMD-side DSC passthrough plumbing exists upstream, but the DisplayID/VESA fixed-BPP parser and DRM connector/mode propagation path carried here still appears absent. The docs now keep that split explicit and keep local QP/RC adjustments behind measured-evidence discipline.

## Related

- #25

## Validation

- `git diff --check`
- `nix flake check --no-build`
