### PR TITLE
docs: map DSC carry split

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ Build optimizations:
 
 ## Upstream status
 
-As of 2026-04-25, `xr/main` is on `55f63ebff7df`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `27d128c1cff6`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
+As of 2026-04-25, `xr/main` was observed at `0eba001f6bf2`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin fixed-DSC-BPP series and drop this part when it lands. |
-| QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry and decide whether this is evidence-backed upstream material or host-only risk. |
+| VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
+| QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Submit as a small drm-edid/drm-misc candidate after local validation. |
 | SMI and NUMA posture | Platform/runtime validation, not a linux-xr source patch | Keep kernel config support here; keep validators, tuned profiles, and host captures in Dell-7810/XoxdWM surfaces. |
 | PREEMPT_RT | Mainline since 6.12; this repo still downloads RT patches for the configured 6.19.x RT build lane | Re-evaluate when the RPM lane moves to a kernel whose RT posture is fully mainline for our target release. |

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -17,13 +17,16 @@ Carry order is defined in `xr/patches/series`.
     absent from the current upstream checkout
   - reduction path: split the DisplayID/parser/connector path from local QP
     table and RC offset adjustments before deciding what still needs submission
+  - current public thread: `[PATCH v7 0/7] VESA DisplayID fixed DSC BPP value support`
+    at <https://patchew.org/linux/20251202110218.9212-1-iam%40lach.pw/>
+  - local split map: `xr/patches/0007-vesa-dsc-bpp.map.md`
 - `xr/patches/bigscreen-beyond-edid.patch`
   - state: upstream candidate
   - reason: Bigscreen Beyond non-desktop quirk remains absent from upstream `drm_edid.c`
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `55f63ebff7df`
+- linux-xr `xr/main`: `0eba001f6bf2`
 - upstream `master` observed from kernel.org: `897d54018cc9`
 - latest upstream tag observed locally: `v7.0`
 - latest `6.19.y` stable tag observed locally: `v6.19.14`
@@ -47,6 +50,11 @@ upstream tree is this carry's DisplayID VESA DSC BPP parser and the public DRM
 connector/mode propagation names `dp_dsc_bpp_x16`,
 `DISPLAYID_VESA_DSC_BPP_*`, and `dsc_passthrough_timings_support`. Keep QP/RC
 table changes separate until measured evidence justifies them.
+
+The latest public DSC-BPP thread found during the 2026-04-25 refresh is v7, not
+the older v6 thread. v7 keeps the same strategic implication for linux-xr:
+parser/connector/amdgpu fixed-BPP handling is upstream-overlap work; QP table
+and RC offset hunks are local-risk carry until separately evidenced.
 
 ## Kernel Cadence
 

--- a/xr/patches/0007-vesa-dsc-bpp.map.md
+++ b/xr/patches/0007-vesa-dsc-bpp.map.md
@@ -1,0 +1,40 @@
+# `0007-vesa-dsc-bpp.patch` Carry Map
+
+This file decomposes the combined DSC carry into upstream-trackable and
+local-risk groups. Keep it current until the patch is split in `series`.
+
+## Upstream Watch
+
+Observed on 2026-04-25:
+
+- Current public series: Yaroslav Bolyukin's `[PATCH v7 0/7] VESA DisplayID
+  fixed DSC BPP value support`.
+- Series cover letter: <https://patchew.org/linux/20251202110218.9212-1-iam%40lach.pw/>
+- EDID parser patch: <https://patchew.org/linux/20251202110218.9212-1-iam%40lach.pw/20251202110218.9212-7-iam%40lach.pw/>
+- AMDGPU usage patch: <https://patchew.org/linux/20251202110218.9212-1-iam%40lach.pw/20251202110218.9212-8-iam%40lach.pw/>
+
+The v7 thread is more current than the older v6 references. Treat the
+DisplayID parser, DRM connector/mode propagation, and amdgpu fixed-BPP usage
+as the upstream-overlap path. Treat QP table and RC offset changes separately
+until measured evidence justifies submitting or retaining them.
+
+## Hunk Groups
+
+| Group | Files | Classification | Notes |
+| --- | --- | --- | --- |
+| DisplayID parser and DRM propagation | `drivers/gpu/drm/drm_displayid_internal.h`, `drivers/gpu/drm/drm_edid.c`, `include/drm/drm_connector.h`, `include/drm/drm_modes.h` | upstream-overlap | Maps to the v7 EDID/DisplayID parser series. This carries `DISPLAYID_VESA_DSC_BPP_*`, `dp_dsc_bpp_x16`, and `dsc_passthrough_timings_support`. |
+| AMDGPU fixed-BPP use | `drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c` | upstream-overlap | Maps to v7 `drm/amd: use fixed dsc bits-per-pixel from edid`. |
+| QP table correction | `drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h` | local-risk carry | Changes min/max QP table entries for 8bpc 4:4:4. This is not part of the v7 upstream DSC-BPP series. |
+| RC offset correction | `drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c` | local-risk carry | Changes the 8 BPP 4:4:4 RC offset path. This needs headset/display-link evidence before upstream treatment. |
+
+## Split Plan
+
+1. Split parser and DRM propagation into `0007a-vesa-displayid-dsc-bpp-parser.patch`.
+2. Split AMDGPU fixed-BPP use into `0007b-amdgpu-use-fixed-dsc-bpp.patch`.
+3. Split QP and RC offsets into `0007c-amdgpu-dsc-qp-rc-local-risk.patch`.
+4. Keep `bigscreen-beyond-edid.patch` independent and after the DSC parser group unless dry-run patch application proves a safer order.
+5. Before changing `xr/patches/series`, run `nix flake check` and a real RPM build lane.
+
+The local-risk group should not be described as upstreamable until the repo
+links measured evidence for the Beyond path and a concrete upstream discussion
+or drop decision.

--- a/xr/patches/0007-vesa-dsc-bpp.map.md
+++ b/xr/patches/0007-vesa-dsc-bpp.map.md
@@ -36,5 +36,5 @@ until measured evidence justifies submitting or retaining them.
 5. Before changing `xr/patches/series`, run `nix flake check` and a real RPM build lane.
 
 The local-risk group should not be described as upstreamable until the repo
-links measured evidence for the Beyond path and a concrete upstream discussion
-or drop decision.
+links measured evidence for the DSC QP/RC path, such as headset or display-link
+capture, and a concrete upstream discussion or drop decision.

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -9,4 +9,8 @@ Current carry classification:
 - `0007-vesa-dsc-bpp.patch`: carry with partial upstream overlap; upstream has AMD DSC passthrough plumbing, but this tree still carries the DisplayID/VESA DSC fixed-BPP parser and DRM connector/mode propagation path. Split that parser/connector path from local QP/RC offset adjustments before submission.
 - `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk.
 
+Detailed split map:
+
+- [`0007-vesa-dsc-bpp.map.md`](0007-vesa-dsc-bpp.map.md)
+
 The build and release workflows should source patches from here rather than another repo.


### PR DESCRIPTION
## Summary

- refresh upstream-status docs from the older DSC-BPP v6 thread to the current public v7 thread
- update the observed `xr/main` and `upstream/master` refs after syncing the case-sensitive checkout
- add a hunk-level carry map for `0007-vesa-dsc-bpp.patch` so issue #25 can split upstream-overlap code from local QP/RC risk

## Validation

- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh`
- `patch -p1 --dry-run < xr/patches/0007-vesa-dsc-bpp.patch`
- `patch -p1 --dry-run < xr/patches/bigscreen-beyond-edid.patch`
- `git diff --check`
- `bash xr/scripts/generate-cadence-report.sh --upstream-ref upstream/master --max-commits 3 --output /tmp/linux-xr-cadence-report.md`

## Notes

Full `nix flake check` and targeted `nix build .#checks.aarch64-darwin.*` were interrupted because they were spending time materializing the full Linux tree on this Darwin workstation. The direct script and patch checks above cover this documentation/control-plane slice.

Refs #25
Refs #9
Refs #6
