### PR TITLE
docs: annotate Bigscreen EDID upstream route

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ availability, install flow, and kernel carry status.
 ### Phase 2: Verify display + DSC
 
 - [ ] `dmesg | grep "VESA.*DSC.*BPP"` — parser finds BPP=128
-- [ ] `cat /sys/class/drm/card1-DP-2/non_desktop` — shows `1`
+- [ ] Capture the headset DRM connector property showing `non-desktop=1`;
+      use `drm_info`, `modetest`, DRM debugfs, or sysfs if the host exposes it.
 - [ ] `zcat /proc/config.gz | grep PREEMPT_RT` — shows `CONFIG_PREEMPT_RT=y`
 - [ ] Power on Beyond via HID, check link training in dmesg
 - [ ] Verify DSC BPP=8.0 selected by VESA DisplayID parser
@@ -235,13 +236,13 @@ Build optimizations:
 
 ## Upstream status
 
-As of 2026-04-25, `xr/main` was observed at `0eba001f6bf2`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
+As of 2026-04-25, `xr/main` was observed at `2e5d29edc83e`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
-| EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Submit as a small drm-edid/drm-misc candidate after local validation. |
+| EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: capture `non-desktop=1`, regenerate a clean upstream patch, run checkpatch/get_maintainer, and send via the DRM route. |
 | SMI and NUMA posture | Platform/runtime validation, not a linux-xr source patch | Keep kernel config support here; keep validators, tuned profiles, and host captures in Dell-7810/XoxdWM surfaces. |
 | PREEMPT_RT | Mainline since 6.12; this repo still downloads RT patches for the configured 6.19.x RT build lane | Re-evaluate when the RPM lane moves to a kernel whose RT posture is fully mainline for our target release. |
 

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -23,10 +23,15 @@ Carry order is defined in `xr/patches/series`.
 - `xr/patches/bigscreen-beyond-edid.patch`
   - state: upstream candidate
   - reason: Bigscreen Beyond non-desktop quirk remains absent from upstream `drm_edid.c`
+  - route: `xr/patches/bigscreen-beyond-edid.route.md`
+  - current gate: live `honey` EDID identity is captured for `BIG/0x1234`, but
+    a DRM connector-property capture proving `non-desktop=1` is still missing
+  - patch gate: the carry is GNU-patch usable but `git apply --check` fails, so
+    v1 must be regenerated against current upstream or `drm-misc-next`
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `0eba001f6bf2`
+- linux-xr `xr/main`: `2e5d29edc83e`
 - upstream `master` observed from kernel.org: `897d54018cc9`
 - latest upstream tag observed locally: `v7.0`
 - latest `6.19.y` stable tag observed locally: `v6.19.14`
@@ -55,6 +60,27 @@ The latest public DSC-BPP thread found during the 2026-04-25 refresh is v7, not
 the older v6 thread. v7 keeps the same strategic implication for linux-xr:
 parser/connector/amdgpu fixed-BPP handling is upstream-overlap work; QP table
 and RC offset hunks are local-risk carry until separately evidenced.
+
+## Bigscreen Beyond EDID Route
+
+The EDID non-desktop quirk is the first small upstream candidate because it is
+isolated to the DRM EDID quirk table. The current route is:
+
+1. keep GitHub issue #24 and Linear `TIN-612` as the public/internal trackers
+2. capture `honey` headset identity and DRM `non-desktop=1` evidence without
+   restarting services, rebooting, or touching `rke2`
+3. regenerate a clean patch from current upstream or `drm-misc-next`
+4. run `git diff --check`, `scripts/checkpatch.pl`, and a bounded
+   `scripts/get_maintainer.pl --no-git`
+5. send to the DRM EDID/DRM misc route with a human `Signed-off-by`
+6. link the lore thread back to GitHub issue #24 and `TIN-612`
+
+The 2026-04-25 read-only honey probe established `/sys/class/drm/card0-DP-2`
+as connected with a 256-byte EDID whose first 16 bytes include
+`09 27 34 12`, supporting `BIG/0x1234`. It did not prove `non-desktop=1`:
+sysfs did not expose `non_desktop`, `drm_info`, `modetest`, and `edid-decode`
+were missing, unprivileged debugfs state was not readable, and `sudo -n` was
+not available.
 
 ## Kernel Cadence
 

--- a/xr/patches/README.md
+++ b/xr/patches/README.md
@@ -7,10 +7,11 @@ Patch application order is defined in `series`.
 Current carry classification:
 
 - `0007-vesa-dsc-bpp.patch`: carry with partial upstream overlap; upstream has AMD DSC passthrough plumbing, but this tree still carries the DisplayID/VESA DSC fixed-BPP parser and DRM connector/mode propagation path. Split that parser/connector path from local QP/RC offset adjustments before submission.
-- `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk.
+- `bigscreen-beyond-edid.patch`: upstream candidate for the Bigscreen Beyond non-desktop quirk. Keep the release carry separate from the upstream submission route; the current carry is GNU-patch usable but must be regenerated before v1 submission.
 
 Detailed split map:
 
 - [`0007-vesa-dsc-bpp.map.md`](0007-vesa-dsc-bpp.map.md)
+- [`bigscreen-beyond-edid.route.md`](bigscreen-beyond-edid.route.md)
 
 The build and release workflows should source patches from here rather than another repo.

--- a/xr/patches/bigscreen-beyond-edid.route.md
+++ b/xr/patches/bigscreen-beyond-edid.route.md
@@ -1,0 +1,113 @@
+# Bigscreen Beyond EDID Upstream Route
+
+This note is the submission route for `bigscreen-beyond-edid.patch`.
+It keeps the public upstream path separate from the release carry path.
+
+## Tracker
+
+- Public issue: <https://github.com/tinyland-inc/linux-xr/issues/24>
+- Internal execution ticket: `TIN-612`
+- Patch file: `xr/patches/bigscreen-beyond-edid.patch`
+- Target subsystem: DRM EDID quirk table in `drivers/gpu/drm/drm_edid.c`
+- Kernel process refs: `Documentation/process/submitting-patches.rst` and
+  `Documentation/dev-tools/checkpatch.rst`
+
+## Current State
+
+As of 2026-04-25:
+
+- Current upstream `drivers/gpu/drm/drm_edid.c` has no `BIG`, `0x1234`, or
+  `0x5095` quirk.
+- `honey` exposes the live headset path as `/sys/class/drm/card0-DP-2` on
+  `6.19.5-7.xr.el10`.
+- The live EDID header starts with
+  `00 ff ff ff ff ff ff 00 09 27 34 12 d2 04 00 00`, which supports
+  `BIG/0x1234` on the connected headset path.
+- The current carry patch is release-usable with GNU `patch`, but it is not
+  submission-ready: `git apply --check xr/patches/bigscreen-beyond-edid.patch`
+  fails at `drivers/gpu/drm/drm_edid.c:220`.
+- `scripts/checkpatch.pl --no-tree xr/patches/bigscreen-beyond-edid.patch`
+  reports a reference warning; replace the `mail-archive.com` URL with a
+  `lore.kernel.org` URL if possible.
+
+## Submission Gates
+
+Do not send v1 until all of these are true:
+
+1. A fresh `honey` capture proves the connected headset DRM property resolves
+   to `non-desktop=1` with this carry applied.
+2. The evidence bundle includes EDID identity from the same connected path:
+   connector name, status, raw EDID bytes or saved `edid.bin`, decoded
+   manufacturer `BIG`, and product `0x1234` or `0x5095`.
+3. The patch is regenerated against current upstream or `drm-misc-next` using
+   normal kernel patch flow, not copied directly from the release carry file.
+4. `scripts/checkpatch.pl` is clean or any warning is explicitly justified.
+5. Recipients are regenerated with a bounded `scripts/get_maintainer.pl`
+   command.
+6. The mailed patch carries a human `Signed-off-by`.
+
+## Evidence Capture Route
+
+The minimum useful host packet is:
+
+```sh
+hostname
+uname -r
+for c in /sys/class/drm/card*-DP-*; do
+  [ -e "$c/status" ] || continue
+  status="$(cat "$c/status")"
+  enabled="$(cat "$c/enabled" 2>/dev/null || true)"
+  printf '%s status=%s enabled=%s\n' "$c" "$status" "$enabled"
+  [ -r "$c/edid" ] && od -An -tx1 -N16 "$c/edid"
+done
+```
+
+That packet only proves identity. For the upstream gate, also capture the DRM
+connector property that reports non-desktop. On `honey` as observed on
+2026-04-25, `/sys/class/drm/card0-DP-2/non_desktop` was absent, `drm_info`,
+`modetest`, and `edid-decode` were not installed, unprivileged DRM debugfs was
+not readable, and `sudo -n` was unavailable. The next capture therefore needs
+one of:
+
+- a repo-managed read-only DRM property tool installed on the host
+- sops-backed sudo for a read-only debugfs capture from
+  `/sys/kernel/debug/dri/*/state`
+- a packaged host evidence script in the Dell-7810 authority surface
+
+Do not restart services, reboot the machine, or touch `rke2` for this evidence
+capture.
+
+## Patch Preparation Route
+
+Use a clean topic branch from current upstream or `drm-misc-next`, then add the
+quirk directly in `drivers/gpu/drm/drm_edid.c` near the existing headset
+quirks.
+
+Suggested subject:
+
+```text
+drm/edid: Add non-desktop quirk for Bigscreen Beyond HMDs
+```
+
+Keep v1 narrow. If only `BIG/0x1234` has local evidence, submit only that ID or
+explicitly call out why `BIG/0x5095` is included without local proof.
+
+Local checks before sending:
+
+```sh
+git diff --check
+scripts/checkpatch.pl 0001-*.patch
+perl scripts/get_maintainer.pl --no-rolestats --no-git --no-git-fallback -f drivers/gpu/drm/drm_edid.c
+```
+
+The bounded maintainer route observed on 2026-04-25 was:
+
+- Maarten Lankhorst `<maarten.lankhorst@linux.intel.com>`
+- Maxime Ripard `<mripard@kernel.org>`
+- Thomas Zimmermann `<tzimmermann@suse.de>`
+- David Airlie `<airlied@gmail.com>`
+- Simona Vetter `<simona@ffwll.ch>`
+- `dri-devel@lists.freedesktop.org`
+- `linux-kernel@vger.kernel.org`
+
+After sending, link the lore thread back to GitHub issue #24 and `TIN-612`.


### PR DESCRIPTION
## Summary

This documents the Bigscreen Beyond EDID upstream route for TIN-612 / linux-xr #24.

It adds a route note beside `xr/patches/bigscreen-beyond-edid.patch`, links that note from the patch README and upstream status page, and replaces the stale single sysfs `non_desktop` checklist with a connector-property evidence requirement.

## Current gates captured

- Live `honey` EDID identity supports `BIG/0x1234` on `/sys/class/drm/card0-DP-2`.
- `non-desktop=1` is still not captured and remains the evidence gate.
- The current carry patch is GNU-patch usable but not submission-ready because `git apply --check` fails.
- The patch route requires a regenerated upstream-formatted patch, clean checkpatch, bounded get_maintainer, and a human Signed-off-by.

## Validation

- `git diff --check`
- `git diff --no-index --check /dev/null xr/patches/bigscreen-beyond-edid.route.md`
- `patch -p1 --dry-run < xr/patches/0007-vesa-dsc-bpp.patch`
- `patch -p1 --dry-run < xr/patches/bigscreen-beyond-edid.patch`
- `bash -n xr/scripts/build-rpm.sh`
- `bash -n xr/scripts/generate-cadence-report.sh`
- patch series file existence check

`nix flake check` was attempted but interrupted after it sat for over four minutes with no active child process or new output after initial evaluation.
