### PR TITLE
TIN-612: record Bigscreen EDID evidence gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ Build optimizations:
 
 ## Upstream status
 
-As of 2026-04-25, `xr/main` was observed at `2e5d29edc83e`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
+As of 2026-04-25, `xr/main` was observed at `3beda6220731`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
-| EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: capture `non-desktop=1`, regenerate a clean upstream patch, run checkpatch/get_maintainer, and send via the DRM route. |
+| EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |
 | SMI and NUMA posture | Platform/runtime validation, not a linux-xr source patch | Keep kernel config support here; keep validators, tuned profiles, and host captures in Dell-7810/XoxdWM surfaces. |
 | PREEMPT_RT | Mainline since 6.12; this repo still downloads RT patches for the configured 6.19.x RT build lane | Re-evaluate when the RPM lane moves to a kernel whose RT posture is fully mainline for our target release. |
 

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -24,14 +24,14 @@ Carry order is defined in `xr/patches/series`.
   - state: upstream candidate
   - reason: Bigscreen Beyond non-desktop quirk remains absent from upstream `drm_edid.c`
   - route: `xr/patches/bigscreen-beyond-edid.route.md`
-  - current gate: live `honey` EDID identity is captured for `BIG/0x1234`, but
-    a DRM connector-property capture proving `non-desktop=1` is still missing
-  - patch gate: the carry is GNU-patch usable but `git apply --check` fails, so
-    v1 must be regenerated against current upstream or `drm-misc-next`
+  - current evidence: live `honey` EDID identity and DRM connector property are
+    captured for `BIG/0x1234`; `DP-2` reports `non-desktop=1`
+  - patch gate: the carry is now `git apply --check` clean against current
+    `xr/main`; v1 still needs a normal upstream/drm-misc topic branch
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `2e5d29edc83e`
+- linux-xr `xr/main`: `3beda6220731`
 - upstream `master` observed from kernel.org: `897d54018cc9`
 - latest upstream tag observed locally: `v7.0`
 - latest `6.19.y` stable tag observed locally: `v6.19.14`
@@ -77,10 +77,10 @@ isolated to the DRM EDID quirk table. The current route is:
 
 The 2026-04-25 read-only honey probe established `/sys/class/drm/card0-DP-2`
 as connected with a 256-byte EDID whose first 16 bytes include
-`09 27 34 12`, supporting `BIG/0x1234`. It did not prove `non-desktop=1`:
-sysfs did not expose `non_desktop`, `drm_info`, `modetest`, and `edid-decode`
-were missing, unprivileged debugfs state was not readable, and `sudo -n` was
-not available.
+`09 27 34 12`, supporting `BIG/0x1234`. A follow-up Dell-owned libdrm capture
+then proved the connector property: `DP-2` reports `non-desktop=1`. The
+evidence is saved in `Jesssullivan/Dell-7810` at
+`data/captures/honey/drm-connector-properties-2026-04-25.txt`.
 
 ## Kernel Cadence
 

--- a/xr/patches/bigscreen-beyond-edid.patch
+++ b/xr/patches/bigscreen-beyond-edid.patch
@@ -10,28 +10,23 @@ EDID manufacturer code: "BIG" (PnP ID 0x0927)
 - Product 0x5095: Bigscreen Beyond 2e
 
 Ref: https://www.phoronix.com/news/Linux-Bigscreen-Beyond-VR
-Ref: https://www.mail-archive.com/dri-devel@lists.freedesktop.org/msg493878.html
+Link: https://lore.kernel.org/dri-devel/20240517105555.654262-1-contact@scrumplex.net/
 ---
- drivers/gpu/drm/drm_edid.c | 14 +++++++++-----
- 1 file changed, 9 insertions(+), 5 deletions(-)
+ drivers/gpu/drm/drm_edid.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
 --- a/drivers/gpu/drm/drm_edid.c
 +++ b/drivers/gpu/drm/drm_edid.c
 @@ -220,6 +220,10 @@ static const struct edid_quirk {
--	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
--	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
 -
-+	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
-+	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
 +
 +	/* Bigscreen Beyond VR Headsets */
 +	EDID_QUIRK('B', 'I', 'G', 0x1234, BIT(EDID_QUIRK_NON_DESKTOP)),
 +	EDID_QUIRK('B', 'I', 'G', 0x5095, BIT(EDID_QUIRK_NON_DESKTOP)),
 +
--	/* HTC Vive and Vive Pro VR Headsets */
--	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
--	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),
-+	/* HTC Vive and Vive Pro VR Headsets */
-+	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
-+	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	/* HTC Vive and Vive Pro VR Headsets */
+ 	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
+ 	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),

--- a/xr/patches/bigscreen-beyond-edid.route.md
+++ b/xr/patches/bigscreen-beyond-edid.route.md
@@ -23,19 +23,21 @@ As of 2026-04-25:
 - The live EDID header starts with
   `00 ff ff ff ff ff ff 00 09 27 34 12 d2 04 00 00`, which supports
   `BIG/0x1234` on the connected headset path.
-- The current carry patch is release-usable with GNU `patch`, but it is not
-  submission-ready: `git apply --check xr/patches/bigscreen-beyond-edid.patch`
-  fails at `drivers/gpu/drm/drm_edid.c:220`.
-- `scripts/checkpatch.pl --no-tree xr/patches/bigscreen-beyond-edid.patch`
-  reports a reference warning; replace the `mail-archive.com` URL with a
-  `lore.kernel.org` URL if possible.
+- A 2026-04-25 libdrm capture on `honey` proves the live connector property:
+  `connector=DP-2 ... state=connected` and `property=non-desktop value=1`.
+- The carry patch has been cleaned so `git apply --check` succeeds against
+  current `xr/main`.
+- The stale `mail-archive.com` reference has been replaced with a
+  `lore.kernel.org` link to the prior public posting.
 
 ## Submission Gates
 
 Do not send v1 until all of these are true:
 
 1. A fresh `honey` capture proves the connected headset DRM property resolves
-   to `non-desktop=1` with this carry applied.
+   to `non-desktop=1` with this carry applied. Current evidence is saved in
+   `Jesssullivan/Dell-7810` as
+   `data/captures/honey/drm-connector-properties-2026-04-25.txt`.
 2. The evidence bundle includes EDID identity from the same connected path:
    connector name, status, raw EDID bytes or saved `edid.bin`, decoded
    manufacturer `BIG`, and product `0x1234` or `0x5095`.
@@ -65,14 +67,23 @@ done
 That packet only proves identity. For the upstream gate, also capture the DRM
 connector property that reports non-desktop. On `honey` as observed on
 2026-04-25, `/sys/class/drm/card0-DP-2/non_desktop` was absent, `drm_info`,
-`modetest`, and `edid-decode` were not installed, unprivileged DRM debugfs was
-not readable, and `sudo -n` was unavailable. The next capture therefore needs
-one of:
+`modetest`, and `edid-decode` were not installed, and unprivileged DRM debugfs
+state did not include the connector property. The successful evidence path was
+a repo-managed read-only libdrm helper in `Jesssullivan/Dell-7810`:
 
-- a repo-managed read-only DRM property tool installed on the host
-- sops-backed sudo for a read-only debugfs capture from
-  `/sys/kernel/debug/dri/*/state`
-- a packaged host evidence script in the Dell-7810 authority surface
+```sh
+ssh honey 'bash -s /dev/dri/card0' \
+  < scripts/platform/capture-drm-connector-properties
+```
+
+The relevant output was:
+
+```text
+connector=DP-2 id=306 state=connected modes=2
+  property=EDID value=339 prop_id=1 blob_length=256 blob_first16=00 ff ff ff ff ff ff 00 09 27 34 12 d2 04 00 00
+  property=link-status value=0 prop_id=5
+  property=non-desktop value=1 prop_id=6
+```
 
 Do not restart services, reboot the machine, or touch `rke2` for this evidence
 capture.

--- a/xr/patches/bigscreen-beyond-edid.route.md
+++ b/xr/patches/bigscreen-beyond-edid.route.md
@@ -25,6 +25,12 @@ As of 2026-04-25:
   `BIG/0x1234` on the connected headset path.
 - A 2026-04-25 libdrm capture on `honey` proves the live connector property:
   `connector=DP-2 ... state=connected` and `property=non-desktop value=1`.
+- Local hardware evidence currently covers `BIG/0x1234` only. `BIG/0x5095`
+  remains a public-report/route candidate unless we capture a Beyond 2e EDID or
+  decide to narrow v1 to the locally proven ID.
+- The unpatched-baseline behavior was not captured on `honey`. The expected
+  upstream argument is the quirk-table mechanism: without an EDID quirk entry,
+  this manufacturer/product ID is not marked with `EDID_QUIRK_NON_DESKTOP`.
 - The carry patch has been cleaned so `git apply --check` succeeds against
   current `xr/main`.
 - The stale `mail-archive.com` reference has been replaced with a
@@ -40,7 +46,9 @@ Do not send v1 until all of these are true:
    `data/captures/honey/drm-connector-properties-2026-04-25.txt`.
 2. The evidence bundle includes EDID identity from the same connected path:
    connector name, status, raw EDID bytes or saved `edid.bin`, decoded
-   manufacturer `BIG`, and product `0x1234` or `0x5095`.
+   manufacturer `BIG`, and product `0x1234` or `0x5095`. Current local evidence
+   satisfies this for `0x1234`; do not imply local `0x5095` proof until a
+   Beyond 2e capture exists.
 3. The patch is regenerated against current upstream or `drm-misc-next` using
    normal kernel patch flow, not copied directly from the release carry file.
 4. `scripts/checkpatch.pl` is clean or any warning is explicitly justified.
@@ -85,6 +93,10 @@ connector=DP-2 id=306 state=connected modes=2
   property=non-desktop value=1 prop_id=6
 ```
 
+This capture was taken on the XR kernel that carries the quirk. It proves the
+local patched runtime behavior for `BIG/0x1234`; it does not prove the
+unpatched baseline or `BIG/0x5095` hardware behavior.
+
 Do not restart services, reboot the machine, or touch `rke2` for this evidence
 capture.
 
@@ -100,8 +112,9 @@ Suggested subject:
 drm/edid: Add non-desktop quirk for Bigscreen Beyond HMDs
 ```
 
-Keep v1 narrow. If only `BIG/0x1234` has local evidence, submit only that ID or
-explicitly call out why `BIG/0x5095` is included without local proof.
+Keep v1 narrow. As of 2026-04-25, only `BIG/0x1234` has local evidence. Submit
+only that ID, or explicitly state that `BIG/0x5095` is included from the prior
+public report rather than from local hardware capture.
 
 Local checks before sending:
 


### PR DESCRIPTION
## Summary

- records the 2026-04-25 honey libdrm evidence that the Bigscreen Beyond path reports `non-desktop=1`
- fixes the carried EDID patch so `git apply --check` and `checkpatch.pl` pass
- updates the EDID upstream route and upstream status docs from missing-evidence to submission-prep state

## Evidence

- honey kernel: `6.19.5-7.xr.el10`
- connector: `/dev/dri/card0`, `DP-2`, connected
- EDID first16: `00 ff ff ff ff ff ff 00 09 27 34 12 d2 04 00 00`
- DRM property: `property=non-desktop value=1`
- durable capture: `Jesssullivan/Dell-7810:data/captures/honey/drm-connector-properties-2026-04-25.txt`

## Validation

- `git apply --check xr/patches/bigscreen-beyond-edid.patch`
- `patch -p1 --dry-run < xr/patches/bigscreen-beyond-edid.patch`
- `scripts/checkpatch.pl --no-tree xr/patches/bigscreen-beyond-edid.patch`
- `patch -p1 --dry-run < xr/patches/0007-vesa-dsc-bpp.patch`
- `git diff --check -- README.md site/docs/upstream-status.md xr/patches/bigscreen-beyond-edid.route.md`

Closes no issue; advances #24 / TIN-612. The actual upstream submission still needs a topic branch against upstream or drm-misc and a human Signed-off-by.
