### PR TITLE
Gate CVE-2026-31431 kernel builds

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -27,6 +27,14 @@ on:
           - rt
           - generic
         default: 'both'
+      use_ccache:
+        description: 'Restore/save ccache (can add large cache transfer time)'
+        required: true
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+        default: 'false'
 
 jobs:
   build-rpm:
@@ -93,9 +101,14 @@ jobs:
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            .github
+            xr
 
       - name: Restore ccache
-        if: steps.filter.outputs.skip != 'true'
+        if: steps.filter.outputs.skip != 'true' && (github.event_name != 'workflow_dispatch' || inputs.use_ccache == 'true')
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/linux-xr-ccache-${{ matrix.variant.name }}
@@ -182,7 +195,7 @@ jobs:
 
       # Explicit cache saves — not reliant on post hooks that get killed on cancellation
       - name: Save ccache
-        if: always() && steps.filter.outputs.skip != 'true'
+        if: always() && steps.filter.outputs.skip != 'true' && (github.event_name != 'workflow_dispatch' || inputs.use_ccache == 'true')
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/linux-xr-ccache-${{ matrix.variant.name }}

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -163,10 +163,6 @@ jobs:
                 sed -i "s|^#baseurl=http://dl.rockylinux.org|baseurl=https://dl.rockylinux.org|" "$repo"
               done
               dnf install -y --setopt=retries=3 epel-release
-              for repo in /etc/yum.repos.d/rocky*.repo; do
-                sed -i "s|^#mirrorlist=|mirrorlist=|" "$repo"
-                sed -i "s|^baseurl=https://dl.rockylinux.org|#baseurl=http://dl.rockylinux.org|" "$repo"
-              done
               dnf config-manager --set-enabled crb
               dnf install -y --setopt=retries=3 \
                 gcc make elfutils-libelf-devel openssl-devel openssl \

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -110,15 +110,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/rpmbuild/SOURCES/linux-*.tar.xz
-            ~/rpmbuild/SOURCES/patch-*-rt*.patch
+            ${{ runner.temp }}/linux-xr-rpmbuild-${{ matrix.variant.name }}/SOURCES/linux-*.tar.xz
+            ${{ runner.temp }}/linux-xr-rpmbuild-${{ matrix.variant.name }}/SOURCES/patch-*-rt*.patch
           key: sources-${{ steps.version.outputs.kversion }}-${{ steps.version.outputs.rt_version }}
 
       - name: Clean previous RPM outputs
         if: steps.filter.outputs.skip != 'true'
         run: |
-          mkdir -p "${HOME}/rpmbuild/RPMS"
-          find "${HOME}/rpmbuild/RPMS" -type f -name 'kernel-xr*.rpm' -delete
+          RPMBUILD_HOST="${RUNNER_TEMP}/linux-xr-rpmbuild-${{ matrix.variant.name }}"
+          mkdir -p "${RPMBUILD_HOST}/RPMS"
+          find "${RPMBUILD_HOST}/RPMS" -type f -name 'kernel-xr*.rpm' -delete
 
       - name: Build RPMs
         if: steps.filter.outputs.skip != 'true'
@@ -128,10 +129,11 @@ jobs:
           RT_VERSION: ${{ steps.version.outputs.rt_version }}
         run: |
           CCACHE_DIR_HOST="${RUNNER_TEMP}/linux-xr-ccache-${{ matrix.variant.name }}"
-          mkdir -p "${HOME}/rpmbuild" "${CCACHE_DIR_HOST}"
+          RPMBUILD_HOST="${RUNNER_TEMP}/linux-xr-rpmbuild-${{ matrix.variant.name }}"
+          mkdir -p "${RPMBUILD_HOST}" "${CCACHE_DIR_HOST}"
           docker run --rm --network host \
             -v "${GITHUB_WORKSPACE}:/work" \
-            -v "${HOME}/rpmbuild:/root/rpmbuild" \
+            -v "${RPMBUILD_HOST}:/root/rpmbuild" \
             -v "${CCACHE_DIR_HOST}:/work/.ccache" \
             -w /work \
             -e HOME=/root \
@@ -191,8 +193,8 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: |
-            ~/rpmbuild/SOURCES/linux-*.tar.xz
-            ~/rpmbuild/SOURCES/patch-*-rt*.patch
+            ${{ runner.temp }}/linux-xr-rpmbuild-${{ matrix.variant.name }}/SOURCES/linux-*.tar.xz
+            ${{ runner.temp }}/linux-xr-rpmbuild-${{ matrix.variant.name }}/SOURCES/patch-*-rt*.patch
           key: sources-${{ steps.version.outputs.kversion }}-${{ steps.version.outputs.rt_version }}
 
       - name: Upload RPM artifacts
@@ -200,7 +202,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: kernel-xr-rpms-${{ matrix.variant.name }}
-          path: ~/rpmbuild/RPMS/**/*.rpm
+          path: ${{ runner.temp }}/linux-xr-rpmbuild-${{ matrix.variant.name }}/RPMS/**/*.rpm
           retention-days: 30
 
   release:

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -30,11 +30,7 @@ on:
 
 jobs:
   build-rpm:
-    runs-on:
-      - self-hosted
-      - tinyland-nix
-      - nix
-      - linux
+    runs-on: tinyland-nix
     timeout-minutes: 360
     env:
       BUILD_IMAGE: rockylinux/rockylinux:10

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -232,7 +232,9 @@ jobs:
             ## XR Kernel Release
 
             Built from tag `${{ github.ref_name }}` with carry patches from
-            [`xr/patches`](https://github.com/tinyland-inc/linux-xr/tree/xr/main/xr/patches).
+            [`xr/patches`](https://github.com/tinyland-inc/linux-xr/tree/xr/main/xr/patches)
+            and gated security backports from
+            [`xr/security`](https://github.com/tinyland-inc/linux-xr/tree/xr/main/xr/security).
 
             ### Variants
             - **kernel-xr** (generic) — standard preemption
@@ -241,6 +243,7 @@ jobs:
             ### Patches applied
             - `0007-vesa-dsc-bpp.patch` — VESA DisplayID DSC BPP parser + QP/RC fixes
             - `bigscreen-beyond-edid.patch` — EDID non-desktop quirk (BIG/0x1234 + 0x5095)
+            - `cve-2026-31431-algif-aead.patch` — applied automatically for vulnerable 6.19.x bases
             - PREEMPT_RT (RT variant only)
 
             ### Install

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-rpm:
-    runs-on: tinyland-nix
+    runs-on: tinyland-dind
     timeout-minutes: 360
     env:
       BUILD_IMAGE: rockylinux/rockylinux:10

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -32,9 +32,9 @@ jobs:
   build-rpm:
     runs-on:
       - self-hosted
-      - Linux
-      - X64
       - tinyland-nix
+      - nix
+      - linux
     timeout-minutes: 360
     env:
       BUILD_IMAGE: rockylinux/rockylinux:10

--- a/.github/workflows/weekly-cadence.yml
+++ b/.github/workflows/weekly-cadence.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Fetch upstream refs
         run: |
           git fetch --no-tags --prune https://github.com/torvalds/linux.git master:refs/remotes/upstream/master
-          git fetch --tags --prune https://github.com/gregkh/linux.git master:refs/remotes/stable/master
+          git fetch --tags --prune https://github.com/gregkh/linux.git linux-6.19.y:refs/remotes/stable/linux-6.19.y
 
       - name: Generate cadence report
         run: |
@@ -29,7 +29,7 @@ jobs:
           xr/scripts/generate-cadence-report.sh \
             --base-ref HEAD \
             --upstream-ref refs/remotes/upstream/master \
-            --stable-ref refs/remotes/stable/master \
+            --stable-ref refs/remotes/stable/linux-6.19.y \
             --output cadence-report.md
           sed -n '1,200p' cadence-report.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ series
 !/xr/patches/
 !/xr/patches/**
 !/xr/patches/series
+!/xr/security/
+!/xr/security/**
 
 # ctags files
 tags

--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ For a no-build check of the active route:
 ./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only
 ```
 
+For a read-only check of a running host:
+
+```bash
+./xr/scripts/check-cve-2026-31431-live.sh
+ssh honey 'bash -s' < ./xr/scripts/check-cve-2026-31431-live.sh
+```
+
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Build optimizations:
 - `CONFIG_DEBUG_INFO=n` — reduces link-time memory from ~8GB to ~2GB
 - Parallelism capped at `-j4` — prevents OOM on memory-constrained runners
 - ccache with `save-always: true` — warm builds ~1h vs cold ~2h
-- `weekly-cadence.yml` — fetches upstream plus `linux-6.19.y` stable refs, renders a markdown report from `xr/patches/series`, includes the current security watch, and opens a weekly cadence issue
+- `weekly-cadence.yml` — fetches upstream plus `linux-6.19.y` stable refs, renders a markdown report from `xr/patches/series`, checks carry patch application when full source paths are available, includes the current security watch, and opens a weekly cadence issue
 
 ## Version scheme
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ For a read-only check of a running host:
 ssh honey 'bash -s' < ./xr/scripts/check-cve-2026-31431-live.sh
 ```
 
+The live checker treats `initcall_blacklist=algif_aead_init` as the narrow
+preferred boot mitigation and also recognizes the broader Red Hat-documented
+`af_alg_init` and `crypto_authenc_esn_module_init` initcall blacklists.
+
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`

--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ The real RPM release lane remains [`build-kernel.yml`](.github/workflows/build-k
 |-------|---------|
 | `0007-vesa-dsc-bpp.patch` | VESA DisplayID DSC BPP parser, QP table + RC offset fixes for 8bpc 4:4:4 @ 8 BPP |
 | `bigscreen-beyond-edid.patch` | EDID non-desktop quirk for Beyond (BIG/0x1234 + 0x5095) |
+| `cve-2026-31431-algif-aead.patch` | CVE-2026-31431 stable `6.19.y` security backport, applied automatically for vulnerable 6.19.x bases |
 | `patch-6.19.3-rt1.patch` | PREEMPT_RT real-time scheduling (RT variant only, downloaded from kernel.org) |
 
-Patches are maintained in this repository under [`xr/patches`](xr/patches).
+XR carry patches are maintained in this repository under [`xr/patches`](xr/patches).
+Security backports that are not part of the normal XR carry live under
+[`xr/security`](xr/security).
 
 RT motivation comes from possible deadline-sensitive workloads: AD/DA and
 sensor I/O for the BCI server, audio periods/xruns, and XR compositor frame
@@ -226,27 +229,49 @@ Build optimizations:
 - `CONFIG_DEBUG_INFO=n` — reduces link-time memory from ~8GB to ~2GB
 - Parallelism capped at `-j4` — prevents OOM on memory-constrained runners
 - ccache with `save-always: true` — warm builds ~1h vs cold ~2h
-- `weekly-cadence.yml` — fetches upstream refs, renders a markdown report from `xr/patches/series`, and opens a weekly cadence issue
+- `weekly-cadence.yml` — fetches upstream plus `linux-6.19.y` stable refs, renders a markdown report from `xr/patches/series`, includes the current security watch, and opens a weekly cadence issue
 
 ## Version scheme
 
 `6.19.5-2.xr.el10` → `uname -r` outputs `6.19.5-rt1-2.xr.el10`
 
+## Security gate
+
+`xr/scripts/build-rpm.sh` guards CVE-2026-31431 builds. The current gate treats
+`6.19.x` before `6.19.12`, `6.18.x` before `6.18.22`, and release candidates
+before `7.0` as unsafe bases. Vulnerable `6.19.x` builds continue only by
+applying the repo-managed backport in
+[`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch).
+Other vulnerable or unknown bases are refused unless
+`LINUX_XR_ALLOW_CVE_2026_31431=1` is set for explicit validation.
+
+For a no-build check of the active route:
+
+```bash
+./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only
+```
+
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`
-2. Compare against current upstream and stable refs before choosing a merge target
-3. Update `xr/config/base.config` if `honey`'s running base kernel changes
-4. Tag: `git tag -a v6.20.1-xr1 -m "XR kernel 6.20.1"`
-5. CI builds + publishes RPMs
-6. Promote only after `honey` and `yoga` validation
+2. Compare against current upstream and the active 6.19.y stable ref before choosing a merge target
+3. Confirm the cadence security watch is fixed or explicitly waived for validation-only work
+4. Update `xr/config/base.config` if `honey`'s running base kernel changes
+5. Tag: `git tag -a v6.20.1-xr1 -m "XR kernel 6.20.1"`
+6. CI builds + publishes RPMs
+7. Promote only after `honey` and `yoga` validation
 
 ## Upstream status
 
-As of 2026-04-25, `xr/main` was observed at `3beda6220731`. Kernel.org has advanced beyond this repo's `origin/master` snapshot: upstream `master` was observed at `897d54018cc9`, `v7.0` exists, and stable `v6.19.14` exists. The RPM lane still builds the configured `6.19.5` tarball until the cadence item deliberately moves it.
+As of 2026-04-30, the latest published linux-xr release is still
+`v6.19.5-xr8`. Do not promote that line until CVE-2026-31431 is resolved by
+moving to at least `6.19.12` or by releasing a newly built artifact with the
+repo-managed backport. Kernel.org stable `6.19.y` contains the CVE fix as
+`ce42ee423e58`, corresponding to the mainline fix `a664bf3d603d`.
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
+| CVE-2026-31431 / `algif_aead` | Fixed upstream in `7.0` and stable `6.19.12`; current published XR artifacts are `6.19.5`; this repo now carries the `6.19.y` backport for new builds | Rebuild `6.19.5` with the backport or move to a fixed base before promotion. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/flake.nix
+++ b/flake.nix
@@ -69,8 +69,10 @@
             set -euo pipefail
             patch_dir="${self}/xr/patches"
             series_file="$patch_dir/series"
+            security_dir="${self}/xr/security"
 
             test -f "$series_file"
+            test -f "$security_dir/cve-2026-31431-algif-aead.patch"
 
             while IFS= read -r patch; do
               case "$patch" in
@@ -98,8 +100,12 @@
             nativeBuildInputs = with pkgs; [ bash patch ];
           } ''
             set -euo pipefail
-            patch -d "${self}" -p1 --dry-run < "${self}/xr/patches/0007-vesa-dsc-bpp.patch"
-            patch -d "${self}" -p1 --dry-run < "${self}/xr/patches/bigscreen-beyond-edid.patch"
+            if [ -e "${self}/drivers/gpu/drm/drm_edid.c" ]; then
+              patch --batch -d "${self}" -p1 --dry-run < "${self}/xr/patches/0007-vesa-dsc-bpp.patch"
+              patch --batch -d "${self}" -p1 --dry-run < "${self}/xr/patches/bigscreen-beyond-edid.patch"
+            else
+              echo "kernel source paths absent; skipping patch application in sparse checkout"
+            fi
             mkdir -p "$out"
           '';
         });

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
             set -euo pipefail
             bash -n "${self}/xr/scripts/build-rpm.sh"
             bash -n "${self}/xr/scripts/generate-cadence-report.sh"
+            bash -n "${self}/xr/scripts/check-cve-2026-31431-live.sh"
             mkdir -p "$out"
           '';
 

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -12,10 +12,14 @@ set -euo pipefail
 KERNEL_VERSION="6.19.5"
 XR_RELEASE="1"
 RT_VERSION=""
+SECURITY_PREFLIGHT_ONLY=0
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATCH_DIR="${XR_DIR}/patches"
 SERIES_FILE="${PATCH_DIR}/series"
+SECURITY_DIR="${XR_DIR}/security"
+CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
+APPLY_CVE_2026_31431_PATCH=0
 
 usage() {
     echo "Usage: $0 --kernel-version VER --xr-release REL [--rt-version RT_VER]"
@@ -24,7 +28,14 @@ usage() {
     echo "  --kernel-version  Kernel version (default: 6.19.5)"
     echo "  --xr-release      XR release number (default: 1)"
     echo "  --rt-version      RT patch version (e.g., 6.19.3-rt1; empty to skip)"
+    echo "  --security-preflight-only"
+    echo "                    Check security gates and exit before staging/building"
     echo "  --help            Show this help"
+    echo ""
+    echo "Security:"
+    echo "  Vulnerable 6.19.x kernels use the repo-managed CVE-2026-31431 backport."
+    echo "  Other vulnerable or unknown kernels are refused unless"
+    echo "  LINUX_XR_ALLOW_CVE_2026_31431=1 is set for explicit validation."
     exit 1
 }
 
@@ -33,6 +44,7 @@ while [[ $# -gt 0 ]]; do
         --kernel-version) KERNEL_VERSION="$2"; shift 2 ;;
         --xr-release)     XR_RELEASE="$2"; shift 2 ;;
         --rt-version)     RT_VERSION="$2"; shift 2 ;;
+        --security-preflight-only) SECURITY_PREFLIGHT_ONLY=1; shift ;;
         --help)           usage ;;
         *)                echo "Unknown option: $1"; usage ;;
     esac
@@ -41,11 +53,114 @@ done
 KRELEASE="${XR_RELEASE}.xr.el10"
 KMAJOR="${KERNEL_VERSION%%.*}"
 
+cve_2026_31431_status() {
+    local version="$1"
+    local core major minor patch
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    if [[ ! "${major}" =~ ^[0-9]+$ || ! "${minor}" =~ ^[0-9]+$ || ! "${patch}" =~ ^[0-9]+$ ]]; then
+        echo "unknown"
+        return
+    fi
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major > 7 )); then
+        echo "fixed-or-newer"
+        return
+    fi
+
+    if (( major == 7 )); then
+        echo "fixed"
+        return
+    fi
+
+    if (( major == 6 && minor == 19 )); then
+        if (( patch >= 12 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor == 18 )); then
+        if (( patch >= 22 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    echo "unknown"
+}
+
+cve_2026_31431_repo_backport_applies() {
+    local version="$1"
+    local core major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] || return 1
+    (( major == 6 && minor == 19 && patch < 12 ))
+}
+
+enforce_cve_2026_31431_gate() {
+    local status
+
+    status="$(cve_2026_31431_status "${KERNEL_VERSION}")"
+    case "${status}" in
+        vulnerable)
+            if cve_2026_31431_repo_backport_applies "${KERNEL_VERSION}" \
+                && [[ -f "${SECURITY_DIR}/${CVE_2026_31431_PATCH}" ]]; then
+                APPLY_CVE_2026_31431_PATCH=1
+                echo ">>> CVE-2026-31431: ${KERNEL_VERSION} is vulnerable; applying ${CVE_2026_31431_PATCH}."
+            elif [[ "${LINUX_XR_ALLOW_CVE_2026_31431:-}" == "1" ]]; then
+                echo "WARNING: building ${KERNEL_VERSION} despite CVE-2026-31431 vulnerable range."
+                echo "WARNING: this must be limited to explicit forensic or backport-validation work."
+            else
+                echo "ERROR: refusing to build ${KERNEL_VERSION}; it is in the known CVE-2026-31431 vulnerable range." >&2
+                echo "ERROR: use 6.19.12+, 6.18.22+, 7.0+, or add a repo-managed backport for this base." >&2
+                echo "ERROR: set LINUX_XR_ALLOW_CVE_2026_31431=1 only for explicit validation." >&2
+                exit 1
+            fi
+            ;;
+        unknown)
+            if [[ "${LINUX_XR_ALLOW_CVE_2026_31431:-}" == "1" ]]; then
+                echo "WARNING: CVE-2026-31431 fixed status is unknown for ${KERNEL_VERSION}; override accepted."
+            else
+                echo "ERROR: CVE-2026-31431 fixed status is unknown for ${KERNEL_VERSION}." >&2
+                echo "ERROR: update the security gate or set LINUX_XR_ALLOW_CVE_2026_31431=1 for an explicit validation build." >&2
+                exit 1
+            fi
+            ;;
+    esac
+}
+
+enforce_cve_2026_31431_gate
+
 echo "=== linux-xr kernel build ==="
 echo "  Kernel:  ${KERNEL_VERSION}"
 echo "  Release: ${KRELEASE}"
 echo "  RT:      ${RT_VERSION:-disabled}"
+echo "  CVE-2026-31431 backport: ${APPLY_CVE_2026_31431_PATCH}"
 echo ""
+
+if [[ "${SECURITY_PREFLIGHT_ONLY}" == "1" ]]; then
+    echo ">>> Security preflight complete; exiting before rpmbuild staging."
+    exit 0
+fi
 
 # Setup rpmbuild tree
 RPMBUILD="${HOME}/rpmbuild"
@@ -119,7 +234,19 @@ for patch in "${PATCHES[@]}"; do
     install -m 0644 "${PATCH_DIR}/${patch}" "${RPMBUILD}/SOURCES/${patch}"
 done
 
-# --- Step 4: Copy base config ---
+# --- Step 4: Stage security backports from this repo ---
+if [[ "${APPLY_CVE_2026_31431_PATCH}" == "1" ]]; then
+    echo ">>> Staging CVE-2026-31431 backport from ${SECURITY_DIR}..."
+    if [[ ! -f "${SECURITY_DIR}/${CVE_2026_31431_PATCH}" ]]; then
+        echo "ERROR: missing security patch ${SECURITY_DIR}/${CVE_2026_31431_PATCH}"
+        exit 1
+    fi
+    install -m 0644 \
+        "${SECURITY_DIR}/${CVE_2026_31431_PATCH}" \
+        "${RPMBUILD}/SOURCES/${CVE_2026_31431_PATCH}"
+fi
+
+# --- Step 5: Copy base config ---
 echo ">>> Copying base config..."
 if [[ -f "${XR_DIR}/config/base.config" ]]; then
     cp "${XR_DIR}/config/base.config" "${RPMBUILD}/SOURCES/base.config"
@@ -129,18 +256,19 @@ else
     exit 1
 fi
 
-# --- Step 5: Copy spec ---
+# --- Step 6: Copy spec ---
 cp "${XR_DIR}/specs/kernel-xr.spec" "${RPMBUILD}/SPECS/"
 
-# --- Step 6: Skip separate patch test (rpmbuild applies patches in %prep) ---
+# --- Step 7: Skip separate patch test (rpmbuild applies patches in %prep) ---
 echo ">>> Skipping separate patch test (rpmbuild handles patch application)."
 echo ">>> If patches fail to apply, rpmbuild will exit with an error."
 
-# --- Step 7: Build RPMs ---
+# --- Step 8: Build RPMs ---
 echo ">>> Building RPMs..."
 DEFINES=(
     --define "kversion ${KERNEL_VERSION}"
     --define "xr_release ${XR_RELEASE}"
+    --define "apply_cve_2026_31431_patch ${APPLY_CVE_2026_31431_PATCH}"
 )
 
 if [[ -n "${RT_VERSION}" ]]; then
@@ -156,7 +284,7 @@ fi
 
 rpmbuild -bb --nodeps "${DEFINES[@]}" "${RPMBUILD}/SPECS/kernel-xr.spec"
 
-# --- Step 8: Report ---
+# --- Step 9: Report ---
 echo ""
 echo "=== Build complete ==="
 echo "RPMs:"

--- a/xr/scripts/check-cve-2026-31431-live.sh
+++ b/xr/scripts/check-cve-2026-31431-live.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 ASSUME_BACKPORTED=0
 OUTPUT="text"
+INITCALL_BLACKLIST_MITIGATIONS=(
+    algif_aead_init
+    af_alg_init
+    crypto_authenc_esn_module_init
+)
 
 usage() {
     cat <<'EOF'
@@ -82,8 +87,30 @@ version_status() {
     fi
 }
 
-cmdline_has_algif_blacklist() {
-    [[ -r /proc/cmdline ]] && grep -qw 'initcall_blacklist=algif_aead_init' /proc/cmdline
+cmdline_initcall_mitigation() {
+    local token
+    local value
+    local entry
+    local mitigation
+    local entries
+
+    [[ -r /proc/cmdline ]] || return 1
+
+    for token in $(</proc/cmdline); do
+        [[ "${token}" == initcall_blacklist=* ]] || continue
+        value="${token#initcall_blacklist=}"
+        IFS=',' read -r -a entries <<< "${value}"
+        for entry in "${entries[@]}"; do
+            for mitigation in "${INITCALL_BLACKLIST_MITIGATIONS[@]}"; do
+                if [[ "${entry}" == "${mitigation}" ]]; then
+                    echo "${mitigation}"
+                    return 0
+                fi
+            done
+        done
+    done
+
+    return 1
 }
 
 config_value() {
@@ -126,7 +153,7 @@ CVE-2026-31431 live posture
   kernel: ${kernel}
   kernel status: ${status}
   CONFIG_CRYPTO_USER_API_AEAD: ${aead:-unavailable}
-  algif_aead init blacklist: ${blacklist}
+  CVE initcall blacklist: ${blacklist}
   verdict: ${verdict}
   detail: ${detail}
 EOF
@@ -148,7 +175,7 @@ render_markdown() {
     echo "| Kernel | \`$(markdown_cell "${kernel}")\` |"
     echo "| Kernel status | \`$(markdown_cell "${status}")\` |"
     echo "| CONFIG_CRYPTO_USER_API_AEAD | \`$(markdown_cell "${aead:-unavailable}")\` |"
-    echo "| algif_aead init blacklist | \`$(markdown_cell "${blacklist}")\` |"
+    echo "| CVE initcall blacklist | \`$(markdown_cell "${blacklist}")\` |"
     echo "| Verdict | \`$(markdown_cell "${verdict}")\` |"
     echo "| Detail | $(markdown_cell "${detail}") |"
 }
@@ -159,6 +186,7 @@ main() {
     local status
     local aead
     local blacklist="absent"
+    local mitigation
     local verdict
     local detail
     local exit_code
@@ -173,8 +201,8 @@ main() {
         aead=""
     fi
 
-    if [[ "${system}" == "Linux" ]] && cmdline_has_algif_blacklist; then
-        blacklist="present"
+    if [[ "${system}" == "Linux" ]] && mitigation="$(cmdline_initcall_mitigation)"; then
+        blacklist="present (${mitigation})"
     fi
 
     if [[ "${system}" != "Linux" ]]; then
@@ -193,11 +221,11 @@ main() {
         verdict="mitigated"
         detail="AF_ALG AEAD userspace API is disabled in the running kernel config"
         exit_code=0
-    elif [[ "${blacklist}" == "present" ]]; then
+    elif [[ "${blacklist}" != "absent" ]]; then
         verdict="mitigated"
-        detail="algif_aead init is blacklisted on the running kernel command line"
+        detail="affected init path is blacklisted on the running kernel command line"
         exit_code=0
-    elif [[ "${status}" == "vulnerable" && "${aead}" == "y" ]]; then
+    elif [[ "${status}" == "vulnerable" && ( "${aead}" == "y" || "${aead}" == "m" ) ]]; then
         verdict="exposed"
         detail="running kernel is in a vulnerable range and AF_ALG AEAD is enabled"
         exit_code=1

--- a/xr/scripts/check-cve-2026-31431-live.sh
+++ b/xr/scripts/check-cve-2026-31431-live.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Check the running host's exposure to CVE-2026-31431.
+set -euo pipefail
+
+ASSUME_BACKPORTED=0
+OUTPUT="text"
+
+usage() {
+    cat <<'EOF'
+Usage: check-cve-2026-31431-live.sh [options]
+
+Options:
+  --assume-backported  Treat the running vulnerable-range kernel as carrying the
+                       repo-managed CVE-2026-31431 backport
+  --markdown           Emit a markdown table
+  --help               Show this help
+
+Exit status:
+  0  fixed, backported, or mitigated
+  1  known vulnerable and exposed
+  2  unknown kernel status or missing evidence
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --assume-backported) ASSUME_BACKPORTED=1; shift ;;
+        --markdown) OUTPUT="markdown"; shift ;;
+        --help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+kernel_version() {
+    uname -r
+}
+
+kernel_system() {
+    uname -s
+}
+
+kernel_core_version() {
+    local version="$1"
+    local core
+
+    core="${version%%-*}"
+    echo "${core}"
+}
+
+version_status() {
+    local version="$1"
+    local core
+    local major
+    local minor
+    local patch
+
+    core="$(kernel_core_version "${version}")"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    if [[ ! "${major}" =~ ^[0-9]+$ || ! "${minor}" =~ ^[0-9]+$ || ! "${patch}" =~ ^[0-9]+$ ]]; then
+        echo "unknown"
+        return
+    fi
+
+    if (( major >= 7 )); then
+        echo "fixed"
+    elif (( major == 6 && minor == 19 )); then
+        if (( patch >= 12 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( major == 6 && minor == 18 )); then
+        if (( patch >= 22 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    else
+        echo "unknown"
+    fi
+}
+
+cmdline_has_algif_blacklist() {
+    [[ -r /proc/cmdline ]] && grep -qw 'initcall_blacklist=algif_aead_init' /proc/cmdline
+}
+
+config_value() {
+    local key="$1"
+    local version="$2"
+    local config_file="/boot/config-${version}"
+
+    if [[ -r "${config_file}" ]]; then
+        sed -nE "s/^${key}=(.*)$/\\1/p" "${config_file}" | head -n 1
+        return
+    fi
+
+    if [[ -r /proc/config.gz ]] && command -v gzip >/dev/null 2>&1; then
+        gzip -cd /proc/config.gz 2>/dev/null | sed -nE "s/^${key}=(.*)$/\\1/p" | head -n 1
+        return
+    fi
+}
+
+markdown_cell() {
+    local value="$1"
+
+    value="${value//$'\n'/ }"
+    value="${value//|/\\|}"
+    echo "${value}"
+}
+
+render_text() {
+    local system="$1"
+    shift
+    local kernel="$1"
+    local status="$2"
+    local aead="$3"
+    local blacklist="$4"
+    local verdict="$5"
+    local detail="$6"
+
+    cat <<EOF
+CVE-2026-31431 live posture
+  system: ${system}
+  kernel: ${kernel}
+  kernel status: ${status}
+  CONFIG_CRYPTO_USER_API_AEAD: ${aead:-unavailable}
+  algif_aead init blacklist: ${blacklist}
+  verdict: ${verdict}
+  detail: ${detail}
+EOF
+}
+
+render_markdown() {
+    local system="$1"
+    shift
+    local kernel="$1"
+    local status="$2"
+    local aead="$3"
+    local blacklist="$4"
+    local verdict="$5"
+    local detail="$6"
+
+    echo "| Item | Value |"
+    echo "| --- | --- |"
+    echo "| System | \`$(markdown_cell "${system}")\` |"
+    echo "| Kernel | \`$(markdown_cell "${kernel}")\` |"
+    echo "| Kernel status | \`$(markdown_cell "${status}")\` |"
+    echo "| CONFIG_CRYPTO_USER_API_AEAD | \`$(markdown_cell "${aead:-unavailable}")\` |"
+    echo "| algif_aead init blacklist | \`$(markdown_cell "${blacklist}")\` |"
+    echo "| Verdict | \`$(markdown_cell "${verdict}")\` |"
+    echo "| Detail | $(markdown_cell "${detail}") |"
+}
+
+main() {
+    local system
+    local kernel
+    local status
+    local aead
+    local blacklist="absent"
+    local verdict
+    local detail
+    local exit_code
+
+    system="$(kernel_system)"
+    kernel="$(kernel_version)"
+    if [[ "${system}" == "Linux" ]]; then
+        status="$(version_status "${kernel}")"
+        aead="$(config_value CONFIG_CRYPTO_USER_API_AEAD "${kernel}")"
+    else
+        status="not-linux"
+        aead=""
+    fi
+
+    if [[ "${system}" == "Linux" ]] && cmdline_has_algif_blacklist; then
+        blacklist="present"
+    fi
+
+    if [[ "${system}" != "Linux" ]]; then
+        verdict="unknown"
+        detail="this checker only evaluates Linux running kernels"
+        exit_code=2
+    elif [[ "${status}" == "fixed" ]]; then
+        verdict="safe"
+        detail="running kernel is at or above a known fixed floor"
+        exit_code=0
+    elif [[ "${ASSUME_BACKPORTED}" == "1" ]]; then
+        verdict="safe"
+        detail="operator asserted that this running kernel carries the repo-managed backport"
+        exit_code=0
+    elif [[ "${aead}" == "n" || "${aead}" == "is not set" ]]; then
+        verdict="mitigated"
+        detail="AF_ALG AEAD userspace API is disabled in the running kernel config"
+        exit_code=0
+    elif [[ "${blacklist}" == "present" ]]; then
+        verdict="mitigated"
+        detail="algif_aead init is blacklisted on the running kernel command line"
+        exit_code=0
+    elif [[ "${status}" == "vulnerable" && "${aead}" == "y" ]]; then
+        verdict="exposed"
+        detail="running kernel is in a vulnerable range and AF_ALG AEAD is enabled"
+        exit_code=1
+    else
+        verdict="unknown"
+        detail="kernel fixed status or AF_ALG AEAD config could not be proven"
+        exit_code=2
+    fi
+
+    if [[ "${OUTPUT}" == "markdown" ]]; then
+        render_markdown "${system}" "${kernel}" "${status}" "${aead}" "${blacklist}" "${verdict}" "${detail}"
+    else
+        render_text "${system}" "${kernel}" "${status}" "${aead}" "${blacklist}" "${verdict}" "${detail}"
+    fi
+
+    exit "${exit_code}"
+}
+
+main

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -7,6 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATCH_DIR="${XR_DIR}/patches"
 SERIES_FILE="${PATCH_DIR}/series"
+BUILD_SCRIPT="${XR_DIR}/scripts/build-rpm.sh"
+SECURITY_DIR="${XR_DIR}/security"
+
+CVE_2026_31431_MAINLINE_FIX="a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5"
+CVE_2026_31431_6_19_FIX="ce42ee423e58dffa5ec03524054c9d8bfd4f6237"
+CVE_2026_31431_6_18_FIX="fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8"
+CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
 
 BASE_REF="HEAD"
 UPSTREAM_REF=""
@@ -72,8 +79,131 @@ carry_rows() {
     done < "${SERIES_FILE}"
 }
 
+default_kernel_version() {
+    sed -nE 's/^KERNEL_VERSION="([^"]+)"/\1/p' "${BUILD_SCRIPT}" | head -n 1
+}
+
+cve_2026_31431_version_status() {
+    local version="$1"
+    local core major minor patch
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    if [[ ! "${major}" =~ ^[0-9]+$ || ! "${minor}" =~ ^[0-9]+$ || ! "${patch}" =~ ^[0-9]+$ ]]; then
+        echo "unknown"
+        return
+    fi
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major > 7 )); then
+        echo "fixed-or-newer"
+        return
+    fi
+
+    if (( major == 7 )); then
+        echo "fixed"
+        return
+    fi
+
+    if (( major == 6 && minor == 19 )); then
+        if (( patch >= 12 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor == 18 )); then
+        if (( patch >= 22 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    echo "unknown"
+}
+
+cve_2026_31431_repo_backport_applies() {
+    local version="$1"
+    local core major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] || return 1
+    (( major == 6 && minor == 19 && patch < 12 ))
+}
+
+cve_2026_31431_repo_backport_status() {
+    if [[ -f "${SECURITY_DIR}/${CVE_2026_31431_PATCH}" ]]; then
+        echo "present"
+    else
+        echo "missing"
+    fi
+}
+
+cve_2026_31431_build_route_status() {
+    local version="$1"
+    local version_status
+
+    version_status="$(cve_2026_31431_version_status "${version}")"
+    case "${version_status}" in
+        fixed|fixed-or-newer)
+            echo "fixed-base"
+            ;;
+        vulnerable)
+            if cve_2026_31431_repo_backport_applies "${version}"; then
+                if [[ "$(cve_2026_31431_repo_backport_status)" == "present" ]]; then
+                    echo "repo-backport-applied-by-build"
+                else
+                    echo "backport-missing"
+                fi
+            else
+                echo "vulnerable"
+            fi
+            ;;
+        *)
+            echo "${version_status}"
+            ;;
+    esac
+}
+
+ref_contains_commit() {
+    local ref="$1"
+    local commit="$2"
+
+    if [[ -z "${ref}" ]] || ! has_ref "${ref}"; then
+        echo "unavailable"
+        return
+    fi
+
+    if ! git cat-file -e "${commit}^{commit}" >/dev/null 2>&1; then
+        echo "unavailable"
+        return
+    fi
+
+    if git merge-base --is-ancestor "${commit}" "${ref}" >/dev/null 2>&1; then
+        echo "yes"
+    else
+        echo "no"
+    fi
+}
+
 BASE_SHA="$(short_ref "${BASE_REF}")"
 GENERATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+DEFAULT_KERNEL_VERSION="$(default_kernel_version)"
 
 tmp_report="$(mktemp)"
 trap 'rm -f "${tmp_report}"' EXIT
@@ -126,6 +256,19 @@ trap 'rm -f "${tmp_report}"' EXIT
     fi
 
     echo
+    echo "## Security Watch"
+    echo
+    echo "| Item | Status |"
+    echo "| --- | --- |"
+    echo "| CVE-2026-31431 default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(cve_2026_31431_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| CVE-2026-31431 repo backport \`${CVE_2026_31431_PATCH}\` | \`$(cve_2026_31431_repo_backport_status)\` |"
+    echo "| CVE-2026-31431 default build route | \`$(cve_2026_31431_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| CVE-2026-31431 upstream/mainline fix \`${CVE_2026_31431_MAINLINE_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${CVE_2026_31431_MAINLINE_FIX}")\` |"
+    echo "| CVE-2026-31431 6.19.y fix \`${CVE_2026_31431_6_19_FIX:0:12}\` in stable ref | \`$(ref_contains_commit "${STABLE_REF}" "${CVE_2026_31431_6_19_FIX}")\` |"
+    echo
+    echo "Known fixed floors for this gate: \`6.19.12+\`, \`6.18.22+\`, and \`7.0+\`."
+    echo "For vulnerable \`6.19.x\` bases, \`build-rpm.sh\` applies the repo backport when present."
+    echo
     echo "## Stable Summary"
     echo
 
@@ -139,10 +282,11 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo
     echo "## Next Actions"
     echo
-    echo "1. Inspect the upstream-only commit list for merge candidates or conflicts."
-    echo "2. Check whether every patch in \`xr/patches/series\` still applies cleanly."
-    echo "3. Build both generic and RT variants if the carry set is unchanged."
-    echo "4. Promote only after named-host validation on \`honey\` and \`yoga\`."
+    echo "1. Resolve any \`vulnerable\`, \`backport-missing\`, or \`unknown\` default build route before release work."
+    echo "2. Inspect the upstream-only commit list for merge candidates or conflicts."
+    echo "3. Check whether every patch in \`xr/patches/series\` still applies cleanly."
+    echo "4. Build both generic and RT variants if the carry set is unchanged."
+    echo "5. Promote only after named-host validation on \`honey\` and \`yoga\`."
 } > "${tmp_report}"
 
 if [[ "${OUTPUT}" == "-" ]]; then

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -20,6 +20,7 @@ UPSTREAM_REF=""
 STABLE_REF=""
 OUTPUT="-"
 MAX_COMMITS=10
+PATCH_TRIAGE=1
 
 usage() {
     cat <<'EOF'
@@ -31,6 +32,7 @@ Options:
   --stable-ref REF     Stable Linux ref to compare against
   --output PATH        Output markdown file ('-' for stdout)
   --max-commits N      Number of commits to show per section (default: 10)
+  --skip-patch-triage  Do not create temporary worktrees to test patch application
   --help               Show this help
 EOF
 }
@@ -42,6 +44,7 @@ while [[ $# -gt 0 ]]; do
         --stable-ref) STABLE_REF="$2"; shift 2 ;;
         --output) OUTPUT="$2"; shift 2 ;;
         --max-commits) MAX_COMMITS="$2"; shift 2 ;;
+        --skip-patch-triage) PATCH_TRIAGE=0; shift ;;
         --help) usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
@@ -77,6 +80,86 @@ carry_rows() {
         echo "| ${idx} | \`${patch}\` |"
         idx=$((idx + 1))
     done < "${SERIES_FILE}"
+}
+
+markdown_cell() {
+    local value="$1"
+
+    value="${value//$'\n'/ }"
+    value="${value//|/\\|}"
+    echo "${value}"
+}
+
+series_patch_count() {
+    if [[ ! -f "${SERIES_FILE}" ]]; then
+        echo 0
+        return
+    fi
+
+    grep -Ev '^[[:space:]]*($|#)' "${SERIES_FILE}" | wc -l | tr -d ' '
+}
+
+series_apply_status() {
+    local label="$1"
+    local ref="$2"
+    local worktree
+    local err_file
+    local patch
+    local count=0
+    local status="clean"
+    local detail
+
+    if [[ -z "${ref}" ]] || ! has_ref "${ref}"; then
+        echo "| ${label} | \`${ref:-unavailable}\` | \`unavailable\` | ref unavailable |"
+        return
+    fi
+
+    if [[ ! -f "${SERIES_FILE}" ]]; then
+        echo "| ${label} | \`${ref}\` | \`unavailable\` | series missing |"
+        return
+    fi
+
+    worktree="$(mktemp -d)"
+    err_file="$(mktemp)"
+
+    if ! git worktree add --detach --quiet "${worktree}" "${ref}" >"${err_file}" 2>&1; then
+        detail="$(head -n 1 "${err_file}")"
+        rm -rf "${worktree}" "${err_file}"
+        echo "| ${label} | \`${ref}\` | \`unavailable\` | $(markdown_cell "${detail:-worktree checkout failed}") |"
+        return
+    fi
+
+    if [[ "$(git -C "${worktree}" config --bool core.sparseCheckout || true)" == "true" ]]; then
+        detail="checkout is sparse; kernel source paths are unavailable"
+        git worktree remove --force "${worktree}" >/dev/null 2>&1 || rm -rf "${worktree}"
+        rm -f "${err_file}"
+        echo "| ${label} | \`${ref}\` | \`unavailable\` | $(markdown_cell "${detail}") |"
+        return
+    fi
+
+    while IFS= read -r patch; do
+        [[ -z "${patch}" || "${patch}" =~ ^[[:space:]]*# ]] && continue
+        count=$((count + 1))
+        if ! git -C "${worktree}" apply --check "${PATCH_DIR}/${patch}" >"${err_file}" 2>&1; then
+            status="conflict"
+            detail="${patch}: $(head -n 1 "${err_file}")"
+            break
+        fi
+        if ! git -C "${worktree}" apply "${PATCH_DIR}/${patch}" >"${err_file}" 2>&1; then
+            status="conflict"
+            detail="${patch}: $(head -n 1 "${err_file}")"
+            break
+        fi
+    done < "${SERIES_FILE}"
+
+    if [[ "${status}" == "clean" ]]; then
+        detail="${count}/$(series_patch_count) patches apply in series order"
+    fi
+
+    git worktree remove --force "${worktree}" >/dev/null 2>&1 || rm -rf "${worktree}"
+    rm -f "${err_file}"
+
+    echo "| ${label} | \`${ref}\` | \`${status}\` | $(markdown_cell "${detail}") |"
 }
 
 default_kernel_version() {
@@ -268,6 +351,18 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo
     echo "Known fixed floors for this gate: \`6.19.12+\`, \`6.18.22+\`, and \`7.0+\`."
     echo "For vulnerable \`6.19.x\` bases, \`build-rpm.sh\` applies the repo backport when present."
+    echo
+    echo "## Carry Apply Triage"
+    echo
+    echo "| Target | Ref | Status | Detail |"
+    echo "| --- | --- | --- | --- |"
+    if [[ "${PATCH_TRIAGE}" == "1" ]]; then
+        series_apply_status "base" "${BASE_REF}"
+        series_apply_status "upstream" "${UPSTREAM_REF}"
+        series_apply_status "stable" "${STABLE_REF}"
+    else
+        echo "| all | n/a | \`skipped\` | patch triage disabled |"
+    fi
     echo
     echo "## Stable Summary"
     echo

--- a/xr/security/README.md
+++ b/xr/security/README.md
@@ -1,0 +1,12 @@
+# linux-xr security backports
+
+This directory is for release-blocking security fixes that are not part of the
+normal XR carry in `xr/patches/series`.
+
+`xr/scripts/build-rpm.sh` decides when a security backport is required and
+passes the matching RPM spec macro. Do not add files here as general kernel
+feature carry; use `xr/patches/` for that path.
+
+| Patch | Source | Build behavior |
+| --- | --- | --- |
+| `cve-2026-31431-algif-aead.patch` | Linux stable `6.19.y` commit `ce42ee423e58`, backporting mainline `a664bf3d603d` | Applied automatically for vulnerable `6.19.x` bases before RT and XR carry patches |

--- a/xr/security/cve-2026-31431-algif-aead.patch
+++ b/xr/security/cve-2026-31431-algif-aead.patch
@@ -1,0 +1,321 @@
+From ce42ee423e58dffa5ec03524054c9d8bfd4f6237 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 26 Mar 2026 15:30:20 +0900
+Subject: crypto: algif_aead - Revert to operating out-of-place
+
+[ Upstream commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 ]
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ crypto/af_alg.c         |  49 +++++-------------------
+ crypto/algif_aead.c     | 100 +++++++++---------------------------------------
+ crypto/algif_skcipher.c |   6 +--
+ include/crypto/if_alg.h |   5 +--
+ 4 files changed, 34 insertions(+), 126 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index ace8a4dc8e976..bc78c915eabc4 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -637,15 +637,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -660,25 +658,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -690,19 +674,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -727,18 +706,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 79b016a899a1e..dda15bb05e892 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -72,9 +71,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -154,23 +152,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -179,76 +178,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sgt.sgl;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src,
+-			      processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-			struct scatterlist *sg = sgl_prev->sgt.sgl;
+-
+-			sg_unmark_end(sg + sgl_prev->sgt.nents - 1);
+-			sg_chain(sg, sgl_prev->sgt.nents + 1, areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -450,7 +388,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 125d395c5e009..82735e51be108 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -138,7 +138,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -149,7 +149,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -363,7 +363,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	if (ctx->state)
+ 		sock_kzfree_s(sk, ctx->state, crypto_skcipher_statesize(tfm));
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 107b797c33ecf..0cc8fa749f68d 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -230,9 +230,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ 	return PAGE_SIZE <= af_alg_rcvbuf(sk);
+ }
+ 
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_wmem_wakeup(struct sock *sk);
+ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+-- 
+cgit 1.3-korg
+

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -18,6 +18,7 @@
 %global krelease  %{xr_release}.xr.el10
 %{!?rt_version: %global rt_version %{nil}}
 %{!?variant: %global variant %{nil}}
+%{!?apply_cve_2026_31431_patch: %global apply_cve_2026_31431_patch 0}
 %if "%{variant}" == "-rt"
 %global actual_krel_regex ^%{kversion}-rt[^[:space:]]*-%{krelease}$
 %else
@@ -37,6 +38,9 @@ Source1:        base.config
 # XR patches (fetched by build-rpm.sh into SOURCES/)
 Patch0:         0007-vesa-dsc-bpp.patch
 Patch1:         bigscreen-beyond-edid.patch
+%if 0%{?apply_cve_2026_31431_patch}
+Patch2:         cve-2026-31431-algif-aead.patch
+%endif
 
 BuildRequires:  gcc
 BuildRequires:  make
@@ -68,6 +72,9 @@ on AMD GPUs (RDNA2+). Includes:
 - EDID non-desktop quirk for Beyond (BIG/0x1234)
 - DSC QP table corrections for 8bpc 4:4:4 at 8 BPP
 - RC offset fix for ofs[11] in get_ofs_set() CM_444/CM_RGB
+%if 0%{?apply_cve_2026_31431_patch}
+- CVE-2026-31431 algif_aead backport
+%endif
 %if "%{rt_version}" != ""
 - PREEMPT_RT real-time scheduling (%{rt_version})
 %endif
@@ -89,6 +96,11 @@ Userspace API header files for kernel-xr %{kversion}-%{krelease}.
 
 %prep
 %setup -q -n linux-%{kversion}
+
+# Apply security backports before RT and XR carry patches.
+%if 0%{?apply_cve_2026_31431_patch}
+%patch -P2 -p1
+%endif
 
 # Apply RT patch first (if building RT kernel)
 %if "%{rt_version}" != ""


### PR DESCRIPTION
## Summary

- add a repo-managed CVE-2026-31431 stable `6.19.y` backport under `xr/security`
- teach `build-rpm.sh` to apply that backport automatically for vulnerable `6.19.x` bases, while continuing to block other vulnerable or unknown bases unless explicitly overridden
- wire the guarded RPM spec patch path, cadence security-watch reporting, release notes, README guidance, and Nix checks around the new security backport
- harden the dind RPM proof lane with sparse checkout, optional manual ccache, stable Rocky baseurl use, and shared runner/RPMBUILD artifact paths

## Why

The published `v6.19.5-xr8` line is on a vulnerable base for CVE-2026-31431. This change makes new `6.19.5` builds use the stable backport path instead of silently producing unsafe artifacts, while still allowing a later move to `6.19.12+` to build without the backport.

## Validation

- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.12 --xr-release 9 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19-rc1 --xr-release 9 --security-preflight-only` blocks as expected
- `git diff --check -- . ':!xr/security/cve-2026-31431-algif-aead.patch'`
- `git apply --check` of the imported backport against upstream stable `v6.19.5` source subset
- `nix flake check` passed locally before the workflow-only follow-ups
- Determinate CI is green on head `2502707598b1d75bbdaeaf7361e9fda542e4d679`
- Manual RPM proof run passed for generic and RT: https://github.com/tinyland-inc/linux-xr/actions/runs/25202336642
  - `kernel-xr-rpms-generic` artifact uploaded, 140,869,157 bytes
  - `kernel-xr-rpms-rt` artifact uploaded, 142,016,515 bytes
  - logs show `CVE-2026-31431 backport: 1`, `Patch #2 (cve-2026-31431-algif-aead.patch)`, patching of `crypto/af_alg.c`, `crypto/algif_aead.c`, `crypto/algif_skcipher.c`, and `include/crypto/if_alg.h`, plus `CC crypto/algif_aead.o` for both variants

Live host installation/boot validation has not been performed by this PR.