### PR TITLE
Gate SELinux security config

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,19 @@ The live checker treats `initcall_blacklist=algif_aead_init` as the narrow
 preferred boot mitigation and also recognizes the broader Red Hat-documented
 `af_alg_init` and `crypto_authenc_esn_module_init` initcall blacklists.
 
+## SELinux and Security Config
+
+`linux-xr` is expected to preserve the Rocky/RHEL SELinux security contract:
+SELinux is built in, selected as the default security module, backed by audit
+and filesystem security-label support, and accompanied by lockdown, Yama,
+Landlock, BPF LSM, IMA, EVM, module signatures, and the existing hardening
+defaults.
+
+The reusable guard is [`xr/scripts/check-security-config.sh`](xr/scripts/check-security-config.sh).
+It is run by `nix flake check` against [`xr/config/base.config`](xr/config/base.config)
+and by the RPM build against the post-`olddefconfig` `.config`, so kernel config
+drift fails before an RPM can be accepted.
+
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,15 @@
             bash -n "${self}/xr/scripts/build-rpm.sh"
             bash -n "${self}/xr/scripts/generate-cadence-report.sh"
             bash -n "${self}/xr/scripts/check-cve-2026-31431-live.sh"
+            bash -n "${self}/xr/scripts/check-security-config.sh"
+            mkdir -p "$out"
+          '';
+
+          security-config = pkgs.runCommand "linux-xr-security-config-check" {
+            nativeBuildInputs = with pkgs; [ bash coreutils gnugrep ];
+          } ''
+            set -euo pipefail
+            bash "${self}/xr/scripts/check-security-config.sh" "${self}/xr/config/base.config"
             mkdir -p "$out"
           '';
 

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -18,6 +18,7 @@ XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATCH_DIR="${XR_DIR}/patches"
 SERIES_FILE="${PATCH_DIR}/series"
 SECURITY_DIR="${XR_DIR}/security"
+SECURITY_CONFIG_CHECK="${XR_DIR}/scripts/check-security-config.sh"
 CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
 APPLY_CVE_2026_31431_PATCH=0
 
@@ -257,6 +258,11 @@ else
 fi
 
 # --- Step 6: Copy spec ---
+if [[ ! -f "${SECURITY_CONFIG_CHECK}" ]]; then
+    echo "ERROR: ${SECURITY_CONFIG_CHECK} not found."
+    exit 1
+fi
+install -m 0755 "${SECURITY_CONFIG_CHECK}" "${RPMBUILD}/SOURCES/check-security-config.sh"
 cp "${XR_DIR}/specs/kernel-xr.spec" "${RPMBUILD}/SPECS/"
 
 # --- Step 7: Skip separate patch test (rpmbuild applies patches in %prep) ---

--- a/xr/scripts/check-security-config.sh
+++ b/xr/scripts/check-security-config.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Validate linux-xr kernel security posture after Kconfig resolution.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="${1:-${XR_DIR}/config/base.config}"
+
+usage() {
+    cat <<'EOF'
+Usage: check-security-config.sh [CONFIG]
+
+Validate the linux-xr SELinux-first kernel security contract.
+When CONFIG is omitted, xr/config/base.config is checked.
+EOF
+}
+
+case "${CONFIG_FILE}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+    echo "ERROR: config file not found: ${CONFIG_FILE}" >&2
+    exit 1
+fi
+
+fail=0
+
+config_line() {
+    local key="$1"
+
+    grep -E "^${key}=|^# ${key} is not set" "${CONFIG_FILE}" 2>/dev/null || true
+}
+
+fail_key() {
+    local key="$1"
+    local expected="$2"
+    local actual="$3"
+
+    echo "  FAIL: ${key} expected ${expected}, got ${actual:-MISSING}" >&2
+    fail=1
+}
+
+expect_value() {
+    local key="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(config_line "${key}")"
+    if [[ "${actual}" == "${key}=${expected}" ]]; then
+        echo "  OK: ${key}=${expected}"
+    else
+        fail_key "${key}" "${expected}" "${actual}"
+    fi
+}
+
+expect_disabled_or_absent() {
+    local key="$1"
+    local actual
+
+    actual="$(config_line "${key}")"
+    case "${actual}" in
+        ""|"# ${key} is not set"|"$key=n")
+            echo "  OK: ${key} disabled or absent"
+            ;;
+        *)
+            fail_key "${key}" "disabled or absent" "${actual}"
+            ;;
+    esac
+}
+
+expect_lsm() {
+    local required="$1"
+    local actual
+    local lsm
+
+    actual="$(config_line CONFIG_LSM)"
+    lsm="${actual#CONFIG_LSM=}"
+    lsm="${lsm%\"}"
+    lsm="${lsm#\"}"
+
+    if [[ ",${lsm}," == *",${required},"* ]]; then
+        echo "  OK: CONFIG_LSM includes ${required}"
+    else
+        fail_key CONFIG_LSM "contains ${required}" "${actual}"
+    fi
+}
+
+echo "=== Validating linux-xr SELinux/security config: ${CONFIG_FILE} ==="
+
+# SELinux must be present and the default LSM for Rocky/RHEL-style operation.
+expect_value CONFIG_SECURITY y
+expect_value CONFIG_SECURITYFS y
+expect_value CONFIG_SECURITY_NETWORK y
+expect_value CONFIG_SECURITY_NETWORK_XFRM y
+expect_value CONFIG_SECURITY_PATH y
+expect_value CONFIG_SECURITY_SELINUX y
+expect_value CONFIG_DEFAULT_SECURITY_SELINUX y
+expect_value CONFIG_SECURITY_SELINUX_BOOTPARAM y
+expect_disabled_or_absent CONFIG_SECURITY_SELINUX_DISABLE
+expect_disabled_or_absent CONFIG_SECURITY_WRITABLE_HOOKS
+expect_lsm selinux
+
+# SELinux depends on audit and xattr/security-label support being available.
+expect_value CONFIG_AUDIT y
+expect_value CONFIG_AUDITSYSCALL y
+expect_value CONFIG_TMPFS_XATTR y
+expect_value CONFIG_TMPFS_POSIX_ACL y
+expect_value CONFIG_EXT4_FS_SECURITY y
+expect_value CONFIG_NFS_V4_SECURITY_LABEL y
+expect_value CONFIG_NFSD_V4_SECURITY_LABEL y
+
+# Keep companion LSM and integrity hooks available for lab hardening work.
+expect_value CONFIG_SECURITY_LOCKDOWN_LSM y
+expect_value CONFIG_SECURITY_LOCKDOWN_LSM_EARLY y
+expect_value CONFIG_SECURITY_YAMA y
+expect_value CONFIG_SECURITY_LANDLOCK y
+expect_value CONFIG_BPF_LSM y
+expect_lsm lockdown
+expect_lsm yama
+expect_lsm bpf
+expect_value CONFIG_IMA y
+expect_value CONFIG_IMA_APPRAISE y
+expect_value CONFIG_IMA_LSM_RULES y
+expect_value CONFIG_EVM y
+
+# General hardening options that should not regress in this kernel lane.
+expect_value CONFIG_BPF_UNPRIV_DEFAULT_OFF y
+expect_value CONFIG_HARDENED_USERCOPY y
+expect_value CONFIG_HARDENED_USERCOPY_DEFAULT_ON y
+expect_value CONFIG_SLAB_FREELIST_HARDENED y
+expect_value CONFIG_STRICT_DEVMEM y
+expect_value CONFIG_LSM_MMAP_MIN_ADDR 65535
+expect_value CONFIG_MODULE_SIG y
+expect_value CONFIG_MODULE_SIG_ALL y
+expect_value CONFIG_SYSTEM_TRUSTED_KEYRING y
+expect_value CONFIG_INTEGRITY_TRUSTED_KEYRING y
+
+if [[ "${fail}" -ne 0 ]]; then
+    echo "FATAL: linux-xr security config validation failed." >&2
+    exit 1
+fi
+
+echo "=== linux-xr security config validation passed ==="

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -34,6 +34,7 @@ URL:            https://github.com/tinyland-inc/linux-xr
 
 Source0:        linux-%{kversion}.tar.xz
 Source1:        base.config
+Source2:        check-security-config.sh
 
 # XR patches (fetched by build-rpm.sh into SOURCES/)
 Patch0:         0007-vesa-dsc-bpp.patch
@@ -243,6 +244,8 @@ if [ "$fail" -ne 0 ]; then
     echo "This kernel would fail to boot on systemd 257 (Rocky 10.1)."
     exit 1
 fi
+
+bash %{SOURCE2} .config
 
 # Capture the actual kernel release string (includes -rt1 if RT patched)
 KREL=$(make -s kernelrelease)


### PR DESCRIPTION
## Summary
- add `xr/scripts/check-security-config.sh` to assert the linux-xr SELinux-first kernel config contract
- wire the guard into `nix flake check` and the RPM build after `olddefconfig`
- document the expected Rocky/RHEL-style SELinux, audit, label, LSM, integrity, module-signing, and hardening posture

## Why
linux-xr is ingesting upstream stable and RT work while carrying lab-specific patches. This gives us a build-time stop sign if that work drifts the kernel away from the SELinux-focused security posture expected for Rockies/Rocky lab hosts.

This PR is stacked on the CVE-2026-31431 release branch so PR #35 and the published `v6.19.5-xr9` prerelease artifacts stay anchored to their proven commit.

## Validation
- `bash -n xr/scripts/check-security-config.sh xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh xr/scripts/check-cve-2026-31431-live.sh`
- `bash xr/scripts/check-security-config.sh`
- `bash xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only`
- `git diff --cached --check`
- `nix flake check`

Notes: `nix flake check` passed after staging the new script so it was visible to Nix's Git source copy. The run emitted existing environment warnings for `cache.flakehub.com` 401 and local omission of incompatible non-Darwin systems.
