### PR TITLE
Document CVE and carry rebase checks

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -239,10 +239,19 @@ jobs:
           merge-multiple: true
           path: rpms/
 
+      - name: Generate SHA256SUMS
+        run: |
+          find rpms -type f -name '*.rpm' -print | sort | while IFS= read -r rpm; do
+            sha256sum "$rpm" | sed 's#  .*/#  #'
+          done > SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: rpms/**/*.rpm
+          files: |
+            rpms/**/*.rpm
+            SHA256SUMS
+          overwrite_files: true
           generate_release_notes: true
           body: |
             ## XR Kernel Release

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -82,8 +82,17 @@ jobs:
             KVERSION="${{ inputs.kernel_version }}"
             XR_RELEASE="${{ inputs.xr_release }}"
           fi
-          # RT version comes from the matrix
-          RT_VERSION="${{ matrix.variant.rt_version }}"
+          # Tag builds use the current pinned RT lane. Manual dispatch can test a
+          # newly published RT patch before the repository default moves.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ matrix.variant.name }}" == "rt" ]]; then
+            RT_VERSION="${{ inputs.rt_version }}"
+          else
+            RT_VERSION="${{ matrix.variant.rt_version }}"
+          fi
+          if [[ "${{ matrix.variant.name }}" == "rt" && -z "${RT_VERSION}" ]]; then
+            echo "RT variant requires rt_version."
+            exit 1
+          fi
           echo "kversion=${KVERSION}" >> "$GITHUB_OUTPUT"
           echo "xr_release=${XR_RELEASE}" >> "$GITHUB_OUTPUT"
           echo "rt_version=${RT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ The live checker treats `initcall_blacklist=algif_aead_init` as the narrow
 preferred boot mitigation and also recognizes the broader Red Hat-documented
 `af_alg_init` and `crypto_authenc_esn_module_init` initcall blacklists.
 
+## Known Patched CVEs
+
+Release-blocking security backports live in
+[`xr/security`](xr/security), with source and build-route details in
+[`xr/security/README.md`](xr/security/README.md). Keep this table in sync when
+adding, dropping, or upstreaming a repo-managed CVE patch.
+
+| CVE | Public name | linux-xr status | Repo links | External references |
+| --- | --- | --- | --- | --- |
+| CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` by carrying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream `6.19.12+` and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [Copy Fail](https://copy.fail/) |
+
 ## SELinux and Security Config
 
 `linux-xr` is expected to preserve the Rocky/RHEL SELinux security contract:
@@ -287,15 +298,35 @@ drift fails before an RPM can be accepted.
 
 ## Upstream status
 
-As of 2026-04-30, the latest published linux-xr release is still
-`v6.19.5-xr8`. Do not promote that line until CVE-2026-31431 is resolved by
-moving to at least `6.19.12` or by releasing a newly built artifact with the
-repo-managed backport. Kernel.org stable `6.19.y` contains the CVE fix as
-`ce42ee423e58`, corresponding to the mainline fix `a664bf3d603d`.
+As of 2026-05-01, the latest published secured linux-xr lab release is
+[`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9).
+It keeps the `6.19.5` lab base but carries the repo-managed
+[`CVE-2026-31431`](#known-patched-cves) backport. Kernel.org stable `6.19.y`
+contains the native fix as `ce42ee423e58`, corresponding to the mainline fix
+`a664bf3d603d`; issue
+[#37](https://github.com/tinyland-inc/linux-xr/issues/37) tracks rebasing the
+lab line to the latest suitable `6.19.y` base and triaging all carry patches.
+
+Current ingestion checkpoint:
+
+- Generic `6.19.14` is the next viable stable-base proof target: the XR carry
+  patches in [`xr/patches/series`](xr/patches/series) dry-run cleanly against
+  the `linux-6.19.14` tarball.
+- RT cannot move to `6.19.14` with the current `6.19.3-rt1` patchset: that RT
+  patch fails to dry-run against `6.19.14` in the `8250_port.c` serial driver
+  path. Keep the current RT artifact line on `v6.19.5-xr9` until a compatible
+  RT patchset or local RT refresh is proven.
+- Use [`xr/scripts/check-kernel-carry.sh`](xr/scripts/check-kernel-carry.sh) to
+  repeat this check before bumping build defaults or tagging a release.
+
+```bash
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
+```
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| CVE-2026-31431 / `algif_aead` | Fixed upstream in `7.0` and stable `6.19.12`; current published XR artifacts are `6.19.5`; this repo now carries the `6.19.y` backport for new builds | Rebuild `6.19.5` with the backport or move to a fixed base before promotion. |
+| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable `6.19.12`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase to latest suitable `6.19.y` under issue #37. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ As of 2026-04-25:
 | `yoga` rollout | Proven one-time generic boot | Generic XR RPM install and one-time boot succeeded; stock Rocky remains the persistent fallback. |
 | Install surface | Active | GitHub Pages and stable installer paths live in `site/`. |
 | Patch carry set | Localized | Kernel-owned carry patches live under `xr/patches/`. |
+| Build source | Tarball-based | RPMs are built from kernel.org `linux-${KERNEL_VERSION}.tar.xz` plus this repo's config, spec, carry patches, and security backports; the checked-out kernel source tree is not currently the RPM source input. |
 | Local checkout requirement | Case-sensitive | Linux source checkouts must be on Linux or a case-sensitive filesystem; macOS case-insensitive checkouts corrupt case-distinct kernel paths. |
 
 ## Public Surfaces
@@ -38,6 +39,27 @@ rollback, and RT acceptance records in the companion `Jesssullivan/Dell-7810`
 repo. `linux-xr` may state which kernel features the RPMs ship, but Dell-owned
 captures decide whether `honey` is prepared for RT, BCI, or downstream XR
 validation.
+
+## Build Source Boundary
+
+`linux-xr` currently has two source surfaces:
+
+- Release builds use [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh) to
+  download the selected kernel.org tarball, apply repo-managed security
+  backports, apply [`xr/patches/series`](xr/patches/series), apply optional RT,
+  and build RPMs from the resulting source tree.
+- The checked-out kernel source tree remains useful for upstream comparison and
+  patch development, but it is not the source tree compiled by the RPM workflow
+  until a source-sync branch explicitly makes it so.
+
+As of 2026-05-01, `xr/main`'s checked-out kernel `Makefile` reports `7.0-rc3`
+while the active lab RPM line is `6.19.x`. GitHub also reports `xr/main` as
+diverged from `torvalds/linux:master` by `82` local commits and `16414`
+upstream commits. Treat that as source-sync debt, not as evidence that a
+published RPM skipped its configured tarball input. For the current lab line,
+use issue [#37](https://github.com/tinyland-inc/linux-xr/issues/37) to rebase a
+dedicated source-sync branch to the selected stable target, replay linux-xr
+carry, and only then change build defaults or release tags.
 
 ## Nix / FlakeHub
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ upstream commits. Treat that as source-sync debt, not as evidence that a
 published RPM skipped its configured tarball input. For the current lab line,
 use issue [#37](https://github.com/tinyland-inc/linux-xr/issues/37) to rebase a
 dedicated source-sync branch to the selected stable target, replay linux-xr
-carry, and only then change build defaults or release tags.
+carry, and only then change build defaults or release tags. The operator runbook
+for that work is [`xr/source-sync.md`](xr/source-sync.md).
 
 ## Nix / FlakeHub
 

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ GitHub Release.
 
 Manual dispatch supports building a single variant:
 ```bash
-gh workflow run build-kernel.yml -f variant=generic  # generic only
-gh workflow run build-kernel.yml -f variant=rt       # RT only
-gh workflow run build-kernel.yml -f variant=both     # both (default)
+gh workflow run build-kernel.yml -f kernel_version=6.19.14 -f xr_release=1 -f variant=generic
+gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=9 -f variant=rt -f rt_version=6.19.3-rt1
+gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=9 -f variant=both -f rt_version=6.19.3-rt1
 ```
 
 Build optimizations:

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,7 @@
             bash -n "${self}/xr/scripts/generate-cadence-report.sh"
             bash -n "${self}/xr/scripts/check-cve-2026-31431-live.sh"
             bash -n "${self}/xr/scripts/check-security-config.sh"
+            bash -n "${self}/xr/scripts/check-kernel-carry.sh"
             mkdir -p "$out"
           '';
 

--- a/xr/scripts/check-kernel-carry.sh
+++ b/xr/scripts/check-kernel-carry.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Dry-run linux-xr carry patches against a kernel.org source tarball.
+
+set -euo pipefail
+
+KERNEL_VERSION=""
+RT_VERSION=""
+WORK_DIR=""
+KEEP_WORK=0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PATCH_DIR="${XR_DIR}/patches"
+SERIES_FILE="${PATCH_DIR}/series"
+
+usage() {
+    cat <<'EOF'
+Usage: check-kernel-carry.sh --kernel-version VER [--rt-version RT_VER] [--work-dir DIR] [--keep-work]
+
+Downloads a kernel.org tarball, optionally dry-runs the matching PREEMPT_RT
+patch first, then dry-runs every patch listed in xr/patches/series.
+
+Examples:
+  ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
+  ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --kernel-version)
+            KERNEL_VERSION="$2"
+            shift 2
+            ;;
+        --rt-version)
+            RT_VERSION="$2"
+            shift 2
+            ;;
+        --work-dir)
+            WORK_DIR="$2"
+            shift 2
+            ;;
+        --keep-work)
+            KEEP_WORK=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+require_command() {
+    local command="$1"
+
+    if ! command -v "${command}" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: ${command}" >&2
+        exit 1
+    fi
+}
+
+if [[ -z "${KERNEL_VERSION}" ]]; then
+    echo "ERROR: --kernel-version is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "${SERIES_FILE}" ]]; then
+    echo "ERROR: ${SERIES_FILE} not found." >&2
+    exit 1
+fi
+
+require_command curl
+require_command patch
+require_command tar
+
+if [[ -z "${WORK_DIR}" ]]; then
+    WORK_DIR="${TMPDIR:-/tmp}/linux-xr-carry-${KERNEL_VERSION}${RT_VERSION:+-${RT_VERSION}}"
+fi
+
+mkdir -p "${WORK_DIR}"
+
+KMAJOR="${KERNEL_VERSION%%.*}"
+TARBALL="linux-${KERNEL_VERSION}.tar.xz"
+TARBALL_URL="https://cdn.kernel.org/pub/linux/kernel/v${KMAJOR}.x/${TARBALL}"
+SOURCE_DIR="${WORK_DIR}/linux-${KERNEL_VERSION}"
+
+if [[ ! -f "${WORK_DIR}/${TARBALL}" ]]; then
+    echo ">>> Downloading ${TARBALL_URL}"
+    curl -fSL -o "${WORK_DIR}/${TARBALL}" "${TARBALL_URL}"
+fi
+
+rm -rf "${SOURCE_DIR}"
+tar -C "${WORK_DIR}" -xf "${WORK_DIR}/${TARBALL}"
+
+if [[ -n "${RT_VERSION}" ]]; then
+    require_command xz
+
+    RT_MAJOR="${RT_VERSION%%-*}"
+    RT_KMAJOR="${RT_MAJOR%%.*}"
+    RT_KMINOR="${RT_MAJOR#*.}"
+    RT_KMINOR="${RT_KMINOR%%.*}"
+    RT_PATCH_XZ="patch-${RT_VERSION}.patch.xz"
+    RT_PATCH="patch-${RT_VERSION}.patch"
+    RT_URL="https://cdn.kernel.org/pub/linux/kernel/projects/rt/${RT_KMAJOR}.${RT_KMINOR}/${RT_PATCH_XZ}"
+
+    if [[ ! -f "${WORK_DIR}/${RT_PATCH_XZ}" ]]; then
+        echo ">>> Downloading ${RT_URL}"
+        curl -fSL -o "${WORK_DIR}/${RT_PATCH_XZ}" "${RT_URL}"
+    fi
+    if [[ ! -f "${WORK_DIR}/${RT_PATCH}" ]]; then
+        xz -dk "${WORK_DIR}/${RT_PATCH_XZ}"
+    fi
+
+    echo ">>> Dry-running PREEMPT_RT ${RT_VERSION}"
+    patch --batch -d "${SOURCE_DIR}" -p1 --dry-run < "${WORK_DIR}/${RT_PATCH}"
+fi
+
+echo ">>> Dry-running linux-xr carry patches against ${KERNEL_VERSION}"
+while IFS= read -r patch_file; do
+    case "${patch_file}" in
+        ""|\#*)
+            continue
+            ;;
+    esac
+
+    if [[ ! -f "${PATCH_DIR}/${patch_file}" ]]; then
+        echo "ERROR: missing carry patch ${PATCH_DIR}/${patch_file}" >&2
+        exit 1
+    fi
+
+    echo "    ${patch_file}"
+    patch --batch -d "${SOURCE_DIR}" -p1 --dry-run < "${PATCH_DIR}/${patch_file}"
+done < "${SERIES_FILE}"
+
+echo "=== linux-xr carry dry-run passed for ${KERNEL_VERSION}${RT_VERSION:+ with ${RT_VERSION}} ==="
+
+if [[ "${KEEP_WORK}" == "0" ]]; then
+    rm -rf "${SOURCE_DIR}"
+else
+    echo "Work tree kept at ${SOURCE_DIR}"
+fi

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -1,0 +1,74 @@
+# linux-xr source-sync runbook
+
+This runbook is for syncing the checked-out kernel source tree to a selected
+upstream stable target. It is separate from the RPM proof-build path.
+
+## Current target
+
+As of 2026-05-01:
+
+- Current lab release line: `v6.19.5-xr9`
+- Next generic proof target: `v6.19.14`
+- Stable branch tip checked externally: `linux-6.19.y` at `v6.19.14`
+- RT blocker: `patch-6.19.3-rt1` does not apply to `v6.19.14`
+
+Do not merge `torvalds/linux:master` into an active lab release branch. For the
+current lab line, source sync should target `linux-6.19.y` / `v6.19.14`.
+
+## Boundary
+
+The RPM workflow builds from kernel.org tarballs selected by
+`--kernel-version`, then layers repo-owned config, spec, carry patches, and
+security backports. The checked-out source tree is useful for patch development
+and upstream comparison, but it is not currently the source tree compiled by the
+RPM workflow.
+
+Treat GitHub ahead/behind counts against `torvalds/linux:master` as source-sync
+debt. Do not treat them as evidence that a published RPM skipped its configured
+tarball input.
+
+## Preflight
+
+Run source-sync work from Linux or a case-sensitive filesystem. Avoid default
+macOS case-insensitive checkouts for Linux source truth.
+
+Required checks before moving build defaults or release tags:
+
+```bash
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
+./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only
+```
+
+RT remains separate until a compatible RT patch is proven:
+
+```bash
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
+```
+
+That RT command is expected to fail with the current RT patchset.
+
+## Source-sync procedure
+
+1. Start from a clean, case-sensitive checkout with kernel history available.
+2. Fetch the stable target from the Linux stable tree.
+3. Create a dedicated branch from `v6.19.14`, for example
+   `codex/source-sync-v6.19.14`.
+4. Replay linux-xr-owned overlay files from the active control branch:
+   `.github/`, `README.md`, `flake.nix`, `flake.lock`, `site/`, and `xr/`.
+5. Confirm the top-level `Makefile` reports the intended upstream base.
+6. Run the carry and security preflights above.
+7. Run a generic RPM proof build before changing defaults or tagging.
+8. Keep RT pinned to the last proven RT line until a compatible RT patch or
+   refreshed local RT carry passes.
+
+## Acceptance
+
+A source-sync branch is ready for review when:
+
+- the source tree is based on the selected stable target,
+- linux-xr overlay files are present and reviewed,
+- generic carry dry-run passes,
+- security preflight passes,
+- generic RPM proof artifacts are uploaded,
+- RT is either proven on the same base or explicitly kept on the previous RT
+  line.


### PR DESCRIPTION
## Summary
- document the known patched CVE surface in the README, including Copy Fail as CVE-2026-31431
- update the upstream status section to distinguish the secured `v6.19.5-xr9` backport line from the still-needed `6.19.y` stable ingestion
- add `xr/scripts/check-kernel-carry.sh` to dry-run XR carry patches, and optional RT patching, against kernel.org tarballs
- teach manual RPM workflow dispatch to honor an operator-provided RT patch version for RT proof builds
- generate and upload `SHA256SUMS` with release RPM assets
- clarify the build-source boundary: RPMs are built from kernel.org tarballs, while the checked-out kernel source tree has separate source-sync debt
- add `xr/source-sync.md` as the operator runbook for a controlled `v6.19.14` source-sync branch

## Why
`v6.19.5-xr9` is secured for Copy Fail/CVE-2026-31431 by the repo-managed backport, but it does not contain the full stable commit set from `6.19.6` through `6.19.14`. We need a repeatable way to verify the next stable-base target before changing defaults or tagging.

The repo also has a source-truth split that needed to be explicit: `xr/main`'s checked-out kernel tree reports `7.0-rc3`, while the active lab RPM line builds `6.19.x` tarballs. GitHub reports `xr/main` as diverged from `torvalds/linux:master` by `82` local commits and `16414` upstream commits. That is source-sync debt, not proof that the released RPMs skipped their configured tarball input.

## Current Result
- `v6.19.5-xr9` remains the secured lab kernel release for CVE-2026-31431 / Copy Fail: https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9
- Public `v6.19.5-xr9` release assets were re-downloaded from GitHub and verified against the published `SHA256SUMS`.
- Generic `6.19.14` carry dry-run passes.
- Generic-only `6.19.14` RPM proof completed and is published as a prerelease: https://github.com/tinyland-inc/linux-xr/releases/tag/proof-6.19.14-xr1-generic
- Public `proof-6.19.14-xr1-generic` release assets were re-downloaded from GitHub and verified against the published `SHA256SUMS`.
- RT `6.19.14` with `6.19.3-rt1` fails in `drivers/tty/serial/8250/8250_port.c`, so RT should stay on the current proven `xr9` line until a compatible RT patchset or refresh is proven.
- Source-sync should be a dedicated stable branch based on `linux-6.19.y` / `v6.19.14`; do not merge `torvalds/linux:master` into this release-control PR.

## Validation
- `bash -n xr/scripts/check-kernel-carry.sh xr/scripts/check-security-config.sh xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh xr/scripts/check-cve-2026-31431-live.sh`
- `bash xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 10 --security-preflight-only`
- `./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --work-dir /tmp/linux-xr-6.19.14-carry-check`
- `nix shell nixpkgs#xz -c ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1 --work-dir /tmp/linux-xr-6.19.14-rt-check` failed as expected in `8250_port.c`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-kernel.yml"); puts "yaml ok"'`
- `nix flake check`
- `gh release download v6.19.5-xr9 --repo tinyland-inc/linux-xr`, then `shasum -a 256 -c SHA256SUMS`
- `gh release download proof-6.19.14-xr1-generic --repo tinyland-inc/linux-xr`, then `shasum -a 256 -c SHA256SUMS`
- Determinate CI run 25235194104 passed on PR #38 at `d39c53a322ca0122a3556310973fc6ace8bc743e`

Notes: `nix flake check` passed with the existing `cache.flakehub.com` 401 warnings; on one earlier run a remote builder refused connection and Nix completed successfully on another builder.