### PR TITLE
ci: keep Determinate from publishing kernel tree

### DIFF
--- a/.github/workflows/determinate-ci.yml
+++ b/.github/workflows/determinate-ci.yml
@@ -11,10 +11,9 @@ jobs:
   determinate-ci:
     # This caches and validates the thin Nix surface for linux-xr. It is not
     # the canonical kernel RPM release lane, which remains the Rocky/Linux
-    # workflow in build-kernel.yml.
+    # workflow in build-kernel.yml. Do not opt into FlakeHub publishing here:
+    # this repository is a kernel tree and exceeds FlakeHub's archive limit.
     uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
     permissions:
       id-token: write
       contents: read
-    with:
-      visibility: unlisted


### PR DESCRIPTION
## Summary
- stop opting the linux-xr Determinate CI workflow into FlakeHub publishing
- keep the thin Nix inventory/build validation and cache path intact
- document why publishing is disabled for this kernel tree

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/determinate-ci.yml"); puts "yaml ok"'`
- `git diff --check`
- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh xr/scripts/check-cve-2026-31431-live.sh xr/scripts/check-security-config.sh xr/scripts/check-kernel-carry.sh`

## Context
Post-merge run `25235757382` passed the Determinate inventory and all platform build jobs, then failed only in `determinate-ci / success` because `DeterminateSystems/flakehub-push` rejected the repository archive: `size=263134622; limit=75000000`.
