### PR TITLE
security: expand CVE-2026-31431 affected range gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,12 @@ Build optimizations:
 
 ## Security gate
 
-`xr/scripts/build-rpm.sh` guards CVE-2026-31431 builds. The current gate treats
-`6.19.x` before `6.19.12`, `6.18.x` before `6.18.22`, and release candidates
-before `7.0` as unsafe bases. Vulnerable `6.19.x` builds continue only by
-applying the repo-managed backport in
+`xr/scripts/build-rpm.sh` guards CVE-2026-31431 builds. The current gate follows
+the NVD affected floors, including `5.10.x` before `5.10.254`, `5.15.x` before
+`5.15.204`, `6.1.x` before `6.1.170`, `6.6.x` before `6.6.137`, `6.12.x`
+before `6.12.85`, `6.18.x` before `6.18.22`, `6.19.x` before `6.19.12`, and
+release candidates before `7.0` as unsafe bases. Vulnerable `6.19.x` builds
+continue only by applying the repo-managed backport in
 [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch).
 Other vulnerable or unknown bases are refused unless
 `LINUX_XR_ALLOW_CVE_2026_31431=1` is set for explicit validation.
@@ -294,7 +296,7 @@ adding, dropping, or upstreaming a repo-managed CVE patch.
 
 | CVE | Public name | linux-xr status | Repo links | External references |
 | --- | --- | --- | --- | --- |
-| CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` by carrying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream `6.19.12+` and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [Copy Fail](https://copy.fail/) |
+| CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` by carrying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
 
 ## SELinux and Security Config
 
@@ -349,7 +351,7 @@ Current ingestion checkpoint:
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable `6.19.12`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase to latest suitable `6.19.y` under issue #37. |
+| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase to latest suitable `6.19.y` under issue #37. Treat 6.12-class stock hosts as exposed unless a vendor backport or mitigation is proven. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -100,6 +100,86 @@ cve_2026_31431_status() {
         return
     fi
 
+    if (( major == 6 && minor >= 13 && minor <= 17 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 12 )); then
+        if (( patch >= 85 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor >= 7 && minor <= 11 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 6 )); then
+        if (( patch >= 137 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor >= 2 && minor <= 5 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 1 )); then
+        if (( patch >= 170 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor >= 16 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor == 15 )); then
+        if (( patch >= 204 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 5 && minor >= 11 && minor <= 14 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor == 10 )); then
+        if (( patch >= 254 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( (major == 4 && minor >= 14) || (major == 5 && minor <= 9) )); then
+        echo "vulnerable"
+        return
+    fi
+
     echo "unknown"
 }
 
@@ -132,7 +212,8 @@ enforce_cve_2026_31431_gate() {
                 echo "WARNING: this must be limited to explicit forensic or backport-validation work."
             else
                 echo "ERROR: refusing to build ${KERNEL_VERSION}; it is in the known CVE-2026-31431 vulnerable range." >&2
-                echo "ERROR: use 6.19.12+, 6.18.22+, 7.0+, or add a repo-managed backport for this base." >&2
+                echo "ERROR: use a known fixed upstream floor or add a repo-managed backport for this base." >&2
+                echo "ERROR: known fixed floors include 5.10.254+, 5.15.204+, 6.1.170+, 6.6.137+, 6.12.85+, 6.18.22+, 6.19.12+, and 7.0+." >&2
                 echo "ERROR: set LINUX_XR_ALLOW_CVE_2026_31431=1 only for explicit validation." >&2
                 exit 1
             fi

--- a/xr/scripts/check-cve-2026-31431-live.sh
+++ b/xr/scripts/check-cve-2026-31431-live.sh
@@ -68,7 +68,9 @@ version_status() {
         return
     fi
 
-    if (( major >= 7 )); then
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+    elif (( major >= 7 )); then
         echo "fixed"
     elif (( major == 6 && minor == 19 )); then
         if (( patch >= 12 )); then
@@ -82,6 +84,50 @@ version_status() {
         else
             echo "vulnerable"
         fi
+    elif (( major == 6 && minor >= 13 && minor <= 17 )); then
+        echo "vulnerable"
+    elif (( major == 6 && minor == 12 )); then
+        if (( patch >= 85 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( major == 6 && minor >= 7 && minor <= 11 )); then
+        echo "vulnerable"
+    elif (( major == 6 && minor == 6 )); then
+        if (( patch >= 137 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( major == 6 && minor >= 2 && minor <= 5 )); then
+        echo "vulnerable"
+    elif (( major == 6 && minor == 1 )); then
+        if (( patch >= 170 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( major == 6 && minor == 0 )); then
+        echo "vulnerable"
+    elif (( major == 5 && minor >= 16 )); then
+        echo "vulnerable"
+    elif (( major == 5 && minor == 15 )); then
+        if (( patch >= 204 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( major == 5 && minor >= 11 && minor <= 14 )); then
+        echo "vulnerable"
+    elif (( major == 5 && minor == 10 )); then
+        if (( patch >= 254 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+    elif (( (major == 4 && minor >= 14) || (major == 5 && minor <= 9) )); then
+        echo "vulnerable"
     else
         echo "unknown"
     fi

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -212,6 +212,86 @@ cve_2026_31431_version_status() {
         return
     fi
 
+    if (( major == 6 && minor >= 13 && minor <= 17 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 12 )); then
+        if (( patch >= 85 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor >= 7 && minor <= 11 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 6 )); then
+        if (( patch >= 137 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor >= 2 && minor <= 5 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 1 )); then
+        if (( patch >= 170 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor >= 16 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor == 15 )); then
+        if (( patch >= 204 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 5 && minor >= 11 && minor <= 14 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 5 && minor == 10 )); then
+        if (( patch >= 254 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( (major == 4 && minor >= 14) || (major == 5 && minor <= 9) )); then
+        echo "vulnerable"
+        return
+    fi
+
     echo "unknown"
 }
 
@@ -349,7 +429,7 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo "| CVE-2026-31431 upstream/mainline fix \`${CVE_2026_31431_MAINLINE_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${CVE_2026_31431_MAINLINE_FIX}")\` |"
     echo "| CVE-2026-31431 6.19.y fix \`${CVE_2026_31431_6_19_FIX:0:12}\` in stable ref | \`$(ref_contains_commit "${STABLE_REF}" "${CVE_2026_31431_6_19_FIX}")\` |"
     echo
-    echo "Known fixed floors for this gate: \`6.19.12+\`, \`6.18.22+\`, and \`7.0+\`."
+    echo "Known fixed floors for this gate include: \`5.10.254+\`, \`5.15.204+\`, \`6.1.170+\`, \`6.6.137+\`, \`6.12.85+\`, \`6.18.22+\`, \`6.19.12+\`, and \`7.0+\`."
     echo "For vulnerable \`6.19.x\` bases, \`build-rpm.sh\` applies the repo backport when present."
     echo
     echo "## Carry Apply Triage"

--- a/xr/security/README.md
+++ b/xr/security/README.md
@@ -10,3 +10,7 @@ feature carry; use `xr/patches/` for that path.
 | Patch | Source | Build behavior |
 | --- | --- | --- |
 | `cve-2026-31431-algif-aead.patch` | Linux stable `6.19.y` commit `ce42ee423e58`, backporting mainline `a664bf3d603d` | Applied automatically for vulnerable `6.19.x` bases before RT and XR carry patches |
+
+Other affected kernel lines remain guarded by `xr/scripts/build-rpm.sh`, but do
+not have repo-managed backports here. Use a fixed upstream floor, vendor-fixed
+kernel, or explicit validation override for those bases.


### PR DESCRIPTION
## Summary
- expand the CVE-2026-31431 version classifier to match the broader NVD/CISA KEV affected floors
- keep the repo-managed automatic backport limited to vulnerable 6.19.x bases
- update README/security docs and cadence text so 6.12-class hosts are not treated as merely unknown

## Validation
- `bash -n xr/scripts/build-rpm.sh xr/scripts/check-cve-2026-31431-live.sh xr/scripts/generate-cadence-report.sh`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.12.0 --xr-release 1 --security-preflight-only` refused as vulnerable
- `./xr/scripts/build-rpm.sh --kernel-version 6.12.85 --xr-release 1 --security-preflight-only`
- `git diff --check`
- read-only live checker over SSH: `honey` exposed, `bumble` exposed under updated floors