### PR TITLE
Fix Pages installable release manifest selection

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,19 +29,44 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - name: Generate latest release manifest
+      - name: Generate latest installable release manifest
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
             const path = require("path");
             const { owner, repo } = context.repo;
-            const data = await github.rest.repos.getLatestRelease({ owner, repo });
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const labTagPattern = /^v\d+\.\d+\.\d+-xr\d+$/;
+            const hasRuntimeAsset = (release, pattern) =>
+              (release.assets || []).some((asset) => pattern.test(asset.name));
+            const candidates = releases
+              .filter((release) =>
+                !release.draft &&
+                labTagPattern.test(release.tag_name) &&
+                hasRuntimeAsset(release, /^kernel-xr-[0-9].*\.rpm$/) &&
+                hasRuntimeAsset(release, /^kernel-xr-rt-[0-9].*\.rpm$/)
+              )
+              .sort((a, b) =>
+                new Date(b.published_at || b.created_at) -
+                new Date(a.published_at || a.created_at)
+              );
+            if (candidates.length === 0) {
+              throw new Error("No installable linux-xr lab release found.");
+            }
+            const data = candidates[0];
             const payload = {
-              tag_name: data.data.tag_name,
-              published_at: data.data.published_at,
-              html_url: data.data.html_url,
-              assets: data.data.assets.map((asset) => ({
+              manifest_schema_version: 2,
+              selection: "latest-installable-lab-release",
+              tag_name: data.tag_name,
+              prerelease: data.prerelease,
+              published_at: data.published_at,
+              html_url: data.html_url,
+              assets: data.assets.map((asset) => ({
                 name: asset.name,
                 size: asset.size,
                 browser_download_url: asset.browser_download_url,

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ availability, install flow, and kernel carry status.
 
 ### Phase 1: Install kernel
 
-- [ ] Install from [Releases](https://github.com/tinyland-inc/linux-xr/releases) or the stable Pages installer surface
+- [ ] Install from [Releases](https://github.com/tinyland-inc/linux-xr/releases) or the Pages installer surface for the latest installable lab release
 - [ ] Generic: `curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | bash`
 - [ ] RT: `curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash`
 - [ ] `sudo dnf install ./kernel-xr-6.19.5-*.xr.el10.x86_64.rpm`
@@ -314,7 +314,8 @@ drift fails before an RPM can be accepted.
 ## Kernel upgrade workflow
 
 1. Review the weekly cadence issue opened by `.github/workflows/weekly-cadence.yml`
-2. Compare against current upstream and the active 6.19.y stable ref before choosing a merge target
+2. Compare against current upstream, maintained stable/longterm refs, and any
+   bounded EOL proof target before choosing a merge target
 3. Confirm the cadence security watch is fixed or explicitly waived for validation-only work
 4. Update `xr/config/base.config` if `honey`'s running base kernel changes
 5. Tag: `git tag -a v6.20.1-xr1 -m "XR kernel 6.20.1"`
@@ -323,35 +324,43 @@ drift fails before an RPM can be accepted.
 
 ## Upstream status
 
-As of 2026-05-01, the latest published secured linux-xr lab release is
+As of 2026-05-03, the latest published secured linux-xr lab release is
 [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9).
 It keeps the `6.19.5` lab base but carries the repo-managed
-[`CVE-2026-31431`](#known-patched-cves) backport. Kernel.org stable `6.19.y`
-contains the native fix as `ce42ee423e58`, corresponding to the mainline fix
-`a664bf3d603d`; issue
+[`CVE-2026-31431`](#known-patched-cves) backport. Kernel.org now lists
+`6.19.14` as EOL; it remains useful as a bounded compatibility proof, but it
+should not become the long-lived lab target. Issue
 [#37](https://github.com/tinyland-inc/linux-xr/issues/37) tracks rebasing the
-lab line to the latest suitable `6.19.y` base and triaging all carry patches.
+lab line to a selected maintained stable or longterm base and triaging all
+carry patches.
 
 Current ingestion checkpoint:
 
-- Generic `6.19.14` is the next viable stable-base proof target: the XR carry
+- Generic `6.19.14` is a viable EOL compatibility proof target: the XR carry
   patches in [`xr/patches/series`](xr/patches/series) dry-run cleanly against
-  the `linux-6.19.14` tarball.
+  the `linux-6.19.14` tarball, and the CVE security preflight passes without
+  the repo-managed backport.
+- Generic `6.18.26` longterm and `7.0.3` stable are maintained-base candidates:
+  the XR carry patches dry-run cleanly against both tarballs, and the CVE
+  security preflight passes for both.
 - RT cannot move to `6.19.14` with the current `6.19.3-rt1` patchset: that RT
   patch fails to dry-run against `6.19.14` in the `8250_port.c` serial driver
   path. Keep the current RT artifact line on `v6.19.5-xr9` until a compatible
-  RT patchset or local RT refresh is proven.
+  RT patchset or local RT refresh is proven. The visible kernel.org 6.19 RT
+  directory still only exposes `patch-6.19.3-rt1`.
 - Use [`xr/scripts/check-kernel-carry.sh`](xr/scripts/check-kernel-carry.sh) to
   repeat this check before bumping build defaults or tagging a release.
 
 ```bash
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.26
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.3
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
 ```
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase to latest suitable `6.19.y` under issue #37. Treat 6.12-class stock hosts as exposed unless a vendor backport or mitigation is proven. |
+| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase the generic lane to a maintained target such as `7.0.3` stable or `6.18.26` longterm under issue #37. Treat 6.12-class stock hosts as exposed unless a vendor backport or mitigation is proven. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -4,7 +4,7 @@ title: Upstream Status
 
 # Upstream Status
 
-Baseline date: 2026-04-25
+Baseline date: 2026-05-03
 
 ## Carry Set
 
@@ -31,14 +31,24 @@ Carry order is defined in `xr/patches/series`.
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `3beda6220731`
-- upstream `master` observed from kernel.org: `897d54018cc9`
-- latest upstream tag observed locally: `v7.0`
-- latest `6.19.y` stable tag observed locally: `v6.19.14`
+- linux-xr `xr/main`: `a5aef68c0ff1`
+- upstream `master` observed from kernel.org: `f377d0025eb0`
+- current mainline release candidate observed on kernel.org: `v7.1-rc1`
+- current stable observed on kernel.org: `v7.0.3`
+- current longterm candidates observed on kernel.org: `v6.18.26`, `v6.12.85`
+- latest `6.19.y` stable tag observed on kernel.org: `v6.19.14` `[EOL]`
 
 The current RPM lane still builds the configured `6.19.5` tarball. Moving the
 release lane forward should be a deliberate cadence item, not an incidental
 merge.
+
+`v6.19.14` remains a useful bounded compatibility proof because the generic
+linux-xr carry applies cleanly and the CVE security preflight passes, but it
+should not become the durable lab target now that kernel.org marks the line
+EOL. The maintained generic candidates checked on 2026-05-03 are `v7.0.3`
+stable and `v6.18.26` longterm; the carry dry-run and CVE security preflight
+passed for both. Keep RT pinned to the current `v6.19.5-xr9` line until a
+compatible RT patchset or local RT refresh is proven.
 
 ## Boundary Notes
 

--- a/site/install.md
+++ b/site/install.md
@@ -11,9 +11,9 @@ curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-generic.sh | 
 curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
 ```
 
-The scripts download the latest release assets, install the runtime kernel RPM by default, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
+The scripts download the latest installable lab release assets, install the runtime kernel RPM by default, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
 
-The public `latest.json` manifest is regenerated from the latest published GitHub release and drives the Pages install surface.
+The public `latest.json` manifest is regenerated from the newest non-draft installable `vX.Y.Z-xrN` release with both generic and RT runtime RPMs. This intentionally includes secured lab prereleases such as `v6.19.5-xr9`, while excluding proof-only releases such as `proof-6.19.14-xr1-generic`.
 
 For non-root validation or staged rollout work, both scripts also support:
 

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
-API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
+API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases?per_page=30}"
 MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
 DOWNLOAD_ONLY=0
 PRINT_ASSETS=0
@@ -57,14 +57,61 @@ fi
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-if ! curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/latest.json"; then
-    curl -fsSL "$API_URL" -o "$WORKDIR/latest.json"
-fi
-
-mapfile -t URLS < <(python3 - "$WORKDIR/latest.json" <<'PY'
-import json, re, sys
+if curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/releases.json"; then
+    if ! python3 - "$WORKDIR/releases.json" <<'PY'
+import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
+raise SystemExit(0 if isinstance(data, dict) and data.get("manifest_schema_version") == 2 else 1)
+PY
+    then
+        curl -fsSL "$API_URL" -o "$WORKDIR/releases.json"
+    fi
+else
+    curl -fsSL "$API_URL" -o "$WORKDIR/releases.json"
+fi
+
+mapfile -t RELEASE_LINES < <(python3 - "$WORKDIR/releases.json" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+lab_tag = re.compile(r"^v\d+\.\d+\.\d+-xr\d+$")
+generic_runtime = re.compile(r"kernel-xr-[0-9].*\.rpm$")
+rt_runtime = re.compile(r"kernel-xr-rt-[0-9].*\.rpm$")
+generic_asset = re.compile(r"kernel-xr(?:-(?:devel|headers))?-[^/]+\.rpm$")
+
+
+def published_key(release):
+    return release.get("published_at") or release.get("created_at") or ""
+
+
+def is_installable(release):
+    if release.get("draft"):
+        return False
+    if not lab_tag.fullmatch(release.get("tag_name", "")):
+        return False
+    names = [asset.get("name", "") for asset in release.get("assets", [])]
+    return (
+        any(generic_runtime.fullmatch(name) for name in names)
+        and any(rt_runtime.fullmatch(name) for name in names)
+    )
+
+
+if isinstance(data, list):
+    candidates = sorted(
+        (release for release in data if is_installable(release)),
+        key=published_key,
+        reverse=True,
+    )
+    if not candidates:
+        raise SystemExit("No installable linux-xr lab release found.")
+    data = candidates[0]
+
+print(data["tag_name"])
 for asset in data.get("assets", []):
     name = asset.get("name", "")
     url = asset.get("browser_download_url", "")
@@ -72,20 +119,16 @@ for asset in data.get("assets", []):
         continue
     if name.startswith("kernel-xr-rt-"):
         continue
-    if re.fullmatch(r"kernel-xr(?:-(?:devel|headers))?-[^/]+\.rpm", name):
+    if generic_asset.fullmatch(name):
         print(url)
 PY
 )
 
-TAG="$(python3 - "$WORKDIR/latest.json" <<'PY'
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    print(json.load(fh)["tag_name"])
-PY
-)"
+TAG="${RELEASE_LINES[0]:-}"
+URLS=("${RELEASE_LINES[@]:1}")
 
 if [ "${#URLS[@]}" -eq 0 ]; then
-    echo "No generic RPM assets found in latest release." >&2
+    echo "No generic RPM assets found in latest installable release." >&2
     exit 1
 fi
 

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PAGES_BASE="${PAGES_BASE:-https://tinyland-inc.github.io/linux-xr}"
-API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases/latest}"
+API_URL="${API_URL:-https://api.github.com/repos/tinyland-inc/linux-xr/releases?per_page=30}"
 MANIFEST_URL="${PAGES_BASE}/releases/latest.json"
 DOWNLOAD_ONLY=0
 PRINT_ASSETS=0
@@ -57,33 +57,76 @@ fi
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
-if ! curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/latest.json"; then
-    curl -fsSL "$API_URL" -o "$WORKDIR/latest.json"
-fi
-
-mapfile -t URLS < <(python3 - "$WORKDIR/latest.json" <<'PY'
-import json, re, sys
+if curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/releases.json"; then
+    if ! python3 - "$WORKDIR/releases.json" <<'PY'
+import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
+raise SystemExit(0 if isinstance(data, dict) and data.get("manifest_schema_version") == 2 else 1)
+PY
+    then
+        curl -fsSL "$API_URL" -o "$WORKDIR/releases.json"
+    fi
+else
+    curl -fsSL "$API_URL" -o "$WORKDIR/releases.json"
+fi
+
+mapfile -t RELEASE_LINES < <(python3 - "$WORKDIR/releases.json" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+lab_tag = re.compile(r"^v\d+\.\d+\.\d+-xr\d+$")
+generic_runtime = re.compile(r"kernel-xr-[0-9].*\.rpm$")
+rt_runtime = re.compile(r"kernel-xr-rt-[0-9].*\.rpm$")
+rt_asset = re.compile(r"kernel-xr-rt(?:-(?:devel|headers))?-[^/]+\.rpm$")
+
+
+def published_key(release):
+    return release.get("published_at") or release.get("created_at") or ""
+
+
+def is_installable(release):
+    if release.get("draft"):
+        return False
+    if not lab_tag.fullmatch(release.get("tag_name", "")):
+        return False
+    names = [asset.get("name", "") for asset in release.get("assets", [])]
+    return (
+        any(generic_runtime.fullmatch(name) for name in names)
+        and any(rt_runtime.fullmatch(name) for name in names)
+    )
+
+
+if isinstance(data, list):
+    candidates = sorted(
+        (release for release in data if is_installable(release)),
+        key=published_key,
+        reverse=True,
+    )
+    if not candidates:
+        raise SystemExit("No installable linux-xr lab release found.")
+    data = candidates[0]
+
+print(data["tag_name"])
 for asset in data.get("assets", []):
     name = asset.get("name", "")
     url = asset.get("browser_download_url", "")
     if not url:
         continue
-    if re.fullmatch(r"kernel-xr-rt(?:-(?:devel|headers))?-[^/]+\.rpm", name):
+    if rt_asset.fullmatch(name):
         print(url)
 PY
 )
 
-TAG="$(python3 - "$WORKDIR/latest.json" <<'PY'
-import json, sys
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    print(json.load(fh)["tag_name"])
-PY
-)"
+TAG="${RELEASE_LINES[0]:-}"
+URLS=("${RELEASE_LINES[@]:1}")
 
 if [ "${#URLS[@]}" -eq 0 ]; then
-    echo "No RT RPM assets found in latest release." >&2
+    echo "No RT RPM assets found in latest installable release." >&2
     exit 1
 fi
 

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,15 +5,17 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-05-01:
+As of 2026-05-03:
 
 - Current lab release line: `v6.19.5-xr9`
-- Next generic proof target: `v6.19.14`
-- Stable branch tip checked externally: `linux-6.19.y` at `v6.19.14`
+- Bounded EOL compatibility proof target: `v6.19.14`
+- Maintained generic candidate targets: `v7.0.3` stable and `v6.18.26` longterm
 - RT blocker: `patch-6.19.3-rt1` does not apply to `v6.19.14`
 
 Do not merge `torvalds/linux:master` into an active lab release branch. For the
-current lab line, source sync should target `linux-6.19.y` / `v6.19.14`.
+current lab line, source sync should target the selected maintained stable or
+longterm base. Use `v6.19.14` only as a bounded compatibility proof because
+kernel.org now marks the `6.19.y` line EOL.
 
 ## Boundary
 
@@ -35,8 +37,15 @@ macOS case-insensitive checkouts for Linux source truth.
 Required checks before moving build defaults or release tags:
 
 ```bash
+# Bounded EOL proof only:
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
 ./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only
+
+# Maintained candidate checks:
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.26
+./xr/scripts/build-rpm.sh --kernel-version 6.18.26 --xr-release 1 --security-preflight-only
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.3
+./xr/scripts/build-rpm.sh --kernel-version 7.0.3 --xr-release 1 --security-preflight-only
 ```
 
 RT remains separate until a compatible RT patch is proven:
@@ -50,9 +59,9 @@ That RT command is expected to fail with the current RT patchset.
 ## Source-sync procedure
 
 1. Start from a clean, case-sensitive checkout with kernel history available.
-2. Fetch the stable target from the Linux stable tree.
-3. Create a dedicated branch from `v6.19.14`, for example
-   `codex/source-sync-v6.19.14`.
+2. Fetch the selected stable or longterm target from the Linux stable tree.
+3. Create a dedicated branch from the selected target, for example
+   `codex/source-sync-v7.0.3` or `codex/source-sync-v6.18.26`.
 4. Replay linux-xr-owned overlay files from the active control branch:
    `.github/`, `README.md`, `flake.nix`, `flake.lock`, `site/`, and `xr/`.
 5. Confirm the top-level `Makefile` reports the intended upstream base.


### PR DESCRIPTION
## Summary

- Select the newest non-draft installable `vX.Y.Z-xrN` lab release for the Pages `latest.json` manifest instead of GitHub's stable-only latest release endpoint.
- Keep proof-only releases such as `proof-6.19.14-xr1-generic` out of the public installer path by requiring a normal lab tag plus both generic and RT runtime RPM assets.
- Update the generic/RT installer fallbacks and install docs to match that release-selection rule.
- Refresh upstream-status docs to record `6.19.14` as EOL proof only, with `7.0.3` stable and `6.18.26` longterm as maintained generic candidates.

## Why

`v6.19.5-xr9` is built and downloadable with generic and RT RPMs plus `SHA256SUMS`, but the current public Pages installer still resolves to `v6.19.5-xr8` because the manifest generator uses GitHub's `getLatestRelease`, which ignores prereleases. Including every prerelease would be unsafe because the newer `proof-6.19.14-xr1-generic` release is proof-only and lacks RT assets.

## Validation

- `bash -n site/install/rocky10-generic.sh && bash -n site/install/rocky10-rt.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages.yml")'`
- `git diff --check`
- `MANIFEST_URL=file:///tmp/linux-xr-no-such-manifest.json API_URL=file://<gh-api-release-list> bash site/install/rocky10-generic.sh --print-assets` selected `v6.19.5-xr9`
- `MANIFEST_URL=file:///tmp/linux-xr-no-such-manifest.json API_URL=file://<gh-api-release-list> bash site/install/rocky10-rt.sh --print-assets` selected `v6.19.5-xr9`
- `gh api repos/tinyland-inc/linux-xr/releases --jq '<selector>'` returned `v6.19.5-xr9`
- `./xr/scripts/check-security-config.sh xr/config/base.config`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 7.0.3 --xr-release 1 --security-preflight-only`

Refs: #34, #37, TIN-932.
