### PR TITLE
[codex] Keep Pages deploys branch scoped

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches: ['xr/main']
     paths:
-      # Keep a push-based escape hatch because release events created by
-      # GitHub Actions do not always fan out into a second workflow run.
+      # Pages deploys are branch-scoped by environment policy. Release tags are
+      # still scanned when generating the manifest, but tag-triggered Pages
+      # deployments are intentionally avoided.
       - 'site/**'
       - '.github/workflows/pages.yml'
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/site/install.md
+++ b/site/install.md
@@ -13,7 +13,7 @@ curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
 
 The scripts download the latest installable lab release assets, install the runtime kernel RPM by default, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
 
-The public `latest.json` manifest is regenerated from the newest non-draft installable `vX.Y.Z-xrN` release with both generic and RT runtime RPMs. This intentionally includes secured lab prereleases such as `v6.19.5-xr9`, while excluding proof-only releases such as `proof-6.19.14-xr1-generic`.
+The public `latest.json` manifest is regenerated from the newest non-draft installable `vX.Y.Z-xrN` release with both generic and RT runtime RPMs. This intentionally includes secured lab prereleases such as `v6.19.5-xr9`, while excluding proof-only releases such as `proof-6.19.14-xr1-generic` and `proof-7.0.3-xr1-generic`.
 
 For non-root validation or staged rollout work, both scripts also support:
 


### PR DESCRIPTION
## Summary
- remove release-tag events from the Pages deployment workflow because the `github-pages` environment rejects tag deployments
- keep release scanning inside the manifest generator when the workflow runs from `xr/main` or manual dispatch
- document that the new `proof-7.0.3-xr1-generic` release is proof-only and excluded from `latest.json`

## Validation
- `git diff --check -- .github/workflows/pages.yml site/install.md`
- confirmed live `latest.json` still selects `v6.19.5-xr9` with `latest-installable-lab-release`

## Context
Creating `proof-7.0.3-xr1-generic` triggered the old release-event Pages workflow, and GitHub rejected deployment from the tag ref due to environment protection rules.