### PR TITLE
[codex] Refresh source-sync status

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ drift fails before an RPM can be accepted.
 
 ## Upstream status
 
-As of 2026-05-03, the latest published secured linux-xr lab release is
+As of 2026-05-05, the latest published secured linux-xr lab release is
 [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9).
 It keeps the `6.19.5` lab base but carries the repo-managed
 [`CVE-2026-31431`](#known-patched-cves) backport. Kernel.org now lists

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -4,7 +4,7 @@ title: Upstream Status
 
 # Upstream Status
 
-Baseline date: 2026-05-03
+Baseline date: 2026-05-05
 
 ## Carry Set
 
@@ -31,9 +31,9 @@ Carry order is defined in `xr/patches/series`.
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `a5aef68c0ff1`
-- upstream `master` observed from kernel.org: `f377d0025eb0`
-- current mainline release candidate observed on kernel.org: `v7.1-rc1`
+- linux-xr `xr/main`: `8290ebb6f86d`
+- upstream `master` observed from kernel.org: `a293ec25d59d`
+- current mainline release candidate observed on kernel.org: `v7.1-rc2`
 - current stable observed on kernel.org: `v7.0.3`
 - current longterm candidates observed on kernel.org: `v6.18.26`, `v6.12.85`
 - latest `6.19.y` stable tag observed on kernel.org: `v6.19.14` `[EOL]`
@@ -45,7 +45,7 @@ merge.
 `v6.19.14` remains a useful bounded compatibility proof because the generic
 linux-xr carry applies cleanly and the CVE security preflight passes, but it
 should not become the durable lab target now that kernel.org marks the line
-EOL. The maintained generic candidates checked on 2026-05-03 are `v7.0.3`
+EOL. The maintained generic candidates checked on 2026-05-05 are `v7.0.3`
 stable and `v6.18.26` longterm; the carry dry-run and CVE security preflight
 passed for both. Keep RT pinned to the current `v6.19.5-xr9` line until a
 compatible RT patchset or local RT refresh is proven.

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,7 +5,7 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-05-03:
+As of 2026-05-05:
 
 - Current lab release line: `v6.19.5-xr9`
 - Bounded EOL compatibility proof target: `v6.19.14`


### PR DESCRIPTION
## Summary

- refresh the source-sync runbook and upstream status pages to the 2026-05-05 kernel.org snapshot
- record current `xr/main`, upstream master, and mainline RC observations
- keep the maintained source-sync targets focused on `7.0.3` stable and `6.18.26` longterm

## Validation

- `git diff --check`
- `./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.3 --work-dir /tmp/linux-xr-carry-7.0.3`
- `./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.26 --work-dir /tmp/linux-xr-carry-6.18.26`
- `./xr/scripts/build-rpm.sh --kernel-version 7.0.3 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.18.26 --xr-release 1 --security-preflight-only`
- `nix flake check` on the local compatible system checks

Note: local `nix flake check` warned about an unavailable remote builder and unauthorized FlakeHub cache, then passed; Linux systems were omitted from this macOS run.
