### PR TITLE
[codex] security: gate Dirty Frag backports

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The real RPM release lane remains [`build-kernel.yml`](.github/workflows/build-k
 | `0007-vesa-dsc-bpp.patch` | VESA DisplayID DSC BPP parser, QP table + RC offset fixes for 8bpc 4:4:4 @ 8 BPP |
 | `bigscreen-beyond-edid.patch` | EDID non-desktop quirk for Beyond (BIG/0x1234 + 0x5095) |
 | `cve-2026-31431-algif-aead.patch` | CVE-2026-31431 stable `6.19.y` security backport, applied automatically for vulnerable 6.19.x bases |
+| `dirtyfrag-esp-shared-frag.patch` | Dirty Frag ESP page-cache write hardening, applied automatically for supported vulnerable bases |
+| `dirtyfrag-rxrpc-linearize.patch` | Dirty Frag RxRPC RXKAD in-place decrypt hardening, applied automatically for supported vulnerable bases |
 | `patch-6.19.3-rt1.patch` | PREEMPT_RT real-time scheduling (RT variant only, downloaded from kernel.org) |
 
 XR carry patches are maintained in this repository under [`xr/patches`](xr/patches).
@@ -260,15 +262,24 @@ Build optimizations:
 
 ## Security gate
 
-`xr/scripts/build-rpm.sh` guards CVE-2026-31431 builds. The current gate follows
-the NVD affected floors, including `5.10.x` before `5.10.254`, `5.15.x` before
-`5.15.204`, `6.1.x` before `6.1.170`, `6.6.x` before `6.6.137`, `6.12.x`
-before `6.12.85`, `6.18.x` before `6.18.22`, `6.19.x` before `6.19.12`, and
-release candidates before `7.0` as unsafe bases. Vulnerable `6.19.x` builds
-continue only by applying the repo-managed backport in
+`xr/scripts/build-rpm.sh` guards CVE-2026-31431 and Dirty Frag builds. The
+CVE-2026-31431 gate follows the NVD affected floors, including `5.10.x` before
+`5.10.254`, `5.15.x` before `5.15.204`, `6.1.x` before `6.1.170`, `6.6.x`
+before `6.6.137`, `6.12.x` before `6.12.85`, `6.18.x` before `6.18.22`,
+`6.19.x` before `6.19.12`, and release candidates before `7.0` as unsafe
+bases. Vulnerable `6.19.x` builds continue only by applying the repo-managed
+backport in
 [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch).
 Other vulnerable or unknown bases are refused unless
 `LINUX_XR_ALLOW_CVE_2026_31431=1` is set for explicit validation.
+
+The Dirty Frag gate tracks the ESP shared-frag fix and the separate RxRPC
+RXKAD in-place decrypt sink. Supported vulnerable bases apply
+[`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch)
+and/or
+[`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch)
+as needed. Unsupported vulnerable or unknown bases are refused unless
+`LINUX_XR_ALLOW_DIRTYFRAG=1` is set for explicit validation.
 
 For a no-build check of the active route:
 
@@ -287,16 +298,17 @@ The live checker treats `initcall_blacklist=algif_aead_init` as the narrow
 preferred boot mitigation and also recognizes the broader Red Hat-documented
 `af_alg_init` and `crypto_authenc_esn_module_init` initcall blacklists.
 
-## Known Patched CVEs
+## Known Patched CVEs And Security Backports
 
 Release-blocking security backports live in
 [`xr/security`](xr/security), with source and build-route details in
 [`xr/security/README.md`](xr/security/README.md). Keep this table in sync when
-adding, dropping, or upstreaming a repo-managed CVE patch.
+adding, dropping, or upstreaming a repo-managed CVE or public security backport.
 
 | CVE | Public name | linux-xr status | Repo links | External references |
 | --- | --- | --- | --- | --- |
 | CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` by carrying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
+| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | This branch adds repo-managed ESP and RxRPC backports for supported vulnerable `6.18.x`, `6.19.x`, and `7.0.x` RPM bases. `v6.19.5-xr9` is secured for Copy Fail, but Dirty Frag requires a newer linux-xr build from this branch or an upstream/vendor-fixed base. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
 
 ## SELinux and Security Config
 
@@ -327,7 +339,9 @@ drift fails before an RPM can be accepted.
 As of 2026-05-05, the latest published secured linux-xr lab release is
 [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9).
 It keeps the `6.19.5` lab base but carries the repo-managed
-[`CVE-2026-31431`](#known-patched-cves) backport. Kernel.org now lists
+[`CVE-2026-31431`](#known-patched-cves-and-security-backports) backport.
+Dirty Frag is newer public security work and requires a newer linux-xr build
+from this branch or an upstream/vendor-fixed base. Kernel.org now lists
 `6.19.14` as EOL; it remains useful as a bounded compatibility proof, but it
 should not become the long-lived lab target. Issue
 [#37](https://github.com/tinyland-inc/linux-xr/issues/37) tracks rebasing the
@@ -338,11 +352,11 @@ Current ingestion checkpoint:
 
 - Generic `6.19.14` is a viable EOL compatibility proof target: the XR carry
   patches in [`xr/patches/series`](xr/patches/series) dry-run cleanly against
-  the `linux-6.19.14` tarball, and the CVE security preflight passes without
-  the repo-managed backport.
+  the `linux-6.19.14` tarball, and the security preflight passes by applying
+  the repo-managed Dirty Frag backports.
 - Generic `6.18.26` longterm and `7.0.3` stable are maintained-base candidates:
-  the XR carry patches dry-run cleanly against both tarballs, and the CVE
-  security preflight passes for both.
+  the XR carry patches dry-run cleanly against both tarballs, and the security
+  preflight passes by applying the required repo-managed Dirty Frag backports.
 - RT cannot move to `6.19.14` with the current `6.19.3-rt1` patchset: that RT
   patch fails to dry-run against `6.19.14` in the `8250_port.c` serial driver
   path. Keep the current RT artifact line on `v6.19.5-xr9` until a compatible
@@ -361,6 +375,7 @@ Current ingestion checkpoint:
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
 | CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase the generic lane to a maintained target such as `7.0.3` stable or `6.18.26` longterm under issue #37. Treat 6.12-class stock hosts as exposed unless a vendor backport or mitigation is proven. |
+| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; RxRPC still needs explicit tracking because the public write-up reports no upstream fix at disclosure time | Build and publish a new linux-xr RPM with both Dirty Frag backports for `6.19.x`; keep `7.0.x` source-sync candidates gated until the RxRPC fix is upstream or carried locally. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/net/ipv4/esp4.c
+++ b/net/ipv4/esp4.c
@@ -870,7 +870,8 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
 			nfrags = 1;
 
 			goto skip_cow;
-		} else if (!skb_has_frag_list(skb)) {
+		} else if (!skb_has_frag_list(skb) &&
+			   !skb_has_shared_frag(skb)) {
 			nfrags = skb_shinfo(skb)->nr_frags;
 			nfrags++;
 

--- a/net/ipv4/ip_output.c
+++ b/net/ipv4/ip_output.c
@@ -1233,6 +1233,8 @@ alloc_new_skb:
 			if (err < 0)
 				goto error;
 			copy = err;
+			if (!(flags & MSG_NO_SHARED_FRAGS))
+				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
 			wmem_alloc_delta += copy;
 		} else if (!zc) {
 			int i = skb_shinfo(skb)->nr_frags;

--- a/net/ipv6/esp6.c
+++ b/net/ipv6/esp6.c
@@ -912,7 +912,8 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
 			nfrags = 1;
 
 			goto skip_cow;
-		} else if (!skb_has_frag_list(skb)) {
+		} else if (!skb_has_frag_list(skb) &&
+			   !skb_has_shared_frag(skb)) {
 			nfrags = skb_shinfo(skb)->nr_frags;
 			nfrags++;
 

--- a/net/ipv6/ip6_output.c
+++ b/net/ipv6/ip6_output.c
@@ -1765,6 +1765,8 @@ alloc_new_skb:
 			if (err < 0)
 				goto error;
 			copy = err;
+			if (!(flags & MSG_NO_SHARED_FRAGS))
+				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
 			wmem_alloc_delta += copy;
 		} else if (!zc) {
 			int i = skb_shinfo(skb)->nr_frags;

--- a/net/rxrpc/rxkad.c
+++ b/net/rxrpc/rxkad.c
@@ -567,23 +567,30 @@ static int rxkad_verify_packet_2(struct rxrpc_call *call, struct sk_buff *skb,
  */
 static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
 {
-	struct rxrpc_skb_priv *sp = rxrpc_skb(skb);
+	struct rxrpc_skb_priv *sp;
 	struct skcipher_request	*req;
 	struct rxrpc_crypt iv;
 	struct scatterlist sg;
 	union {
 		__be32 buf[2];
 	} crypto __aligned(8);
-	rxrpc_seq_t seq = sp->hdr.seq;
+	rxrpc_seq_t seq;
 	int ret;
 	u16 cksum;
 	u32 x, y;
 
-	_enter("{%d{%x}},{#%u}",
-	       call->debug_id, key_serial(call->conn->key), seq);
-
 	if (!call->conn->rxkad.cipher)
 		return 0;
+
+	if (call->conn->security_level != RXRPC_SECURITY_PLAIN &&
+	    skb_linearize_cow(skb) < 0)
+		return -ENOMEM;
+
+	sp = rxrpc_skb(skb);
+	seq = sp->hdr.seq;
+
+	_enter("{%d{%x}},{#%u}",
+	       call->debug_id, key_serial(call->conn->key), seq);
 
 	req = rxkad_get_call_crypto(call);
 	if (!req)

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -20,7 +20,11 @@ SERIES_FILE="${PATCH_DIR}/series"
 SECURITY_DIR="${XR_DIR}/security"
 SECURITY_CONFIG_CHECK="${XR_DIR}/scripts/check-security-config.sh"
 CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
+DIRTYFRAG_ESP_PATCH="dirtyfrag-esp-shared-frag.patch"
+DIRTYFRAG_RXRPC_PATCH="dirtyfrag-rxrpc-linearize.patch"
 APPLY_CVE_2026_31431_PATCH=0
+APPLY_DIRTYFRAG_ESP_PATCH=0
+APPLY_DIRTYFRAG_RXRPC_PATCH=0
 
 usage() {
     echo "Usage: $0 --kernel-version VER --xr-release REL [--rt-version RT_VER]"
@@ -37,6 +41,9 @@ usage() {
     echo "  Vulnerable 6.19.x kernels use the repo-managed CVE-2026-31431 backport."
     echo "  Other vulnerable or unknown kernels are refused unless"
     echo "  LINUX_XR_ALLOW_CVE_2026_31431=1 is set for explicit validation."
+    echo "  Dirty Frag ESP/RxRPC page-cache write hardening is required for"
+    echo "  supported vulnerable bases; unsupported vulnerable or unknown bases"
+    echo "  are refused unless LINUX_XR_ALLOW_DIRTYFRAG=1 is set."
     exit 1
 }
 
@@ -53,6 +60,18 @@ done
 
 KRELEASE="${XR_RELEASE}.xr.el10"
 KMAJOR="${KERNEL_VERSION%%.*}"
+
+kernel_version_triplet() {
+    local version="$1"
+    local core major minor patch
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] || return 1
+    echo "${major} ${minor} ${patch}"
+}
 
 cve_2026_31431_status() {
     local version="$1"
@@ -197,6 +216,102 @@ cve_2026_31431_repo_backport_applies() {
     (( major == 6 && minor == 19 && patch < 12 ))
 }
 
+dirtyfrag_esp_status() {
+    local version="$1"
+    local major minor patch
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major > 7 )); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major == 7 && minor == 0 )); then
+        if (( patch >= 5 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && (minor == 18 || minor == 19) )); then
+        echo "vulnerable"
+        return
+    fi
+
+    echo "unknown"
+}
+
+dirtyfrag_esp_repo_backport_applies() {
+    local version="$1"
+    local major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        return 1
+    fi
+
+    (( major == 6 && (minor == 18 || minor == 19) )) ||
+        (( major == 7 && minor == 0 && patch < 5 ))
+}
+
+dirtyfrag_rxrpc_status() {
+    local version="$1"
+    local major minor patch
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major > 7 )); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major == 7 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && (minor == 18 || minor == 19) )); then
+        echo "vulnerable"
+        return
+    fi
+
+    echo "unknown"
+}
+
+dirtyfrag_rxrpc_repo_backport_applies() {
+    local version="$1"
+    local major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        return 1
+    fi
+
+    (( major == 6 && (minor == 18 || minor == 19) )) ||
+        (( major == 7 && minor == 0 ))
+}
+
 enforce_cve_2026_31431_gate() {
     local status
 
@@ -230,13 +345,72 @@ enforce_cve_2026_31431_gate() {
     esac
 }
 
+enforce_dirtyfrag_gate() {
+    local esp_status rxrpc_status
+
+    esp_status="$(dirtyfrag_esp_status "${KERNEL_VERSION}")"
+    case "${esp_status}" in
+        vulnerable)
+            if dirtyfrag_esp_repo_backport_applies "${KERNEL_VERSION}" \
+                && [[ -f "${SECURITY_DIR}/${DIRTYFRAG_ESP_PATCH}" ]]; then
+                APPLY_DIRTYFRAG_ESP_PATCH=1
+                echo ">>> Dirty Frag ESP: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_ESP_PATCH}."
+            elif [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
+                echo "WARNING: building ${KERNEL_VERSION} despite Dirty Frag ESP vulnerable range."
+            else
+                echo "ERROR: refusing to build ${KERNEL_VERSION}; Dirty Frag ESP status is vulnerable and no repo-managed backport route is enabled." >&2
+                echo "ERROR: use a fixed upstream floor, port ${DIRTYFRAG_ESP_PATCH}, or set LINUX_XR_ALLOW_DIRTYFRAG=1 only for explicit validation." >&2
+                exit 1
+            fi
+            ;;
+        unknown)
+            if [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
+                echo "WARNING: Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}; override accepted."
+            else
+                echo "ERROR: Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}." >&2
+                echo "ERROR: update the security gate or set LINUX_XR_ALLOW_DIRTYFRAG=1 for an explicit validation build." >&2
+                exit 1
+            fi
+            ;;
+    esac
+
+    rxrpc_status="$(dirtyfrag_rxrpc_status "${KERNEL_VERSION}")"
+    case "${rxrpc_status}" in
+        vulnerable)
+            if dirtyfrag_rxrpc_repo_backport_applies "${KERNEL_VERSION}" \
+                && [[ -f "${SECURITY_DIR}/${DIRTYFRAG_RXRPC_PATCH}" ]]; then
+                APPLY_DIRTYFRAG_RXRPC_PATCH=1
+                echo ">>> Dirty Frag RxRPC: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_RXRPC_PATCH}."
+            elif [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
+                echo "WARNING: building ${KERNEL_VERSION} despite Dirty Frag RxRPC vulnerable range."
+            else
+                echo "ERROR: refusing to build ${KERNEL_VERSION}; Dirty Frag RxRPC status is vulnerable and no repo-managed backport route is enabled." >&2
+                echo "ERROR: use a fixed upstream floor, port ${DIRTYFRAG_RXRPC_PATCH}, or set LINUX_XR_ALLOW_DIRTYFRAG=1 only for explicit validation." >&2
+                exit 1
+            fi
+            ;;
+        unknown)
+            if [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
+                echo "WARNING: Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}; override accepted."
+            else
+                echo "ERROR: Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}." >&2
+                echo "ERROR: update the security gate or set LINUX_XR_ALLOW_DIRTYFRAG=1 for an explicit validation build." >&2
+                exit 1
+            fi
+            ;;
+    esac
+}
+
 enforce_cve_2026_31431_gate
+enforce_dirtyfrag_gate
 
 echo "=== linux-xr kernel build ==="
 echo "  Kernel:  ${KERNEL_VERSION}"
 echo "  Release: ${KRELEASE}"
 echo "  RT:      ${RT_VERSION:-disabled}"
 echo "  CVE-2026-31431 backport: ${APPLY_CVE_2026_31431_PATCH}"
+echo "  Dirty Frag ESP backport: ${APPLY_DIRTYFRAG_ESP_PATCH}"
+echo "  Dirty Frag RxRPC backport: ${APPLY_DIRTYFRAG_RXRPC_PATCH}"
 echo ""
 
 if [[ "${SECURITY_PREFLIGHT_ONLY}" == "1" ]]; then
@@ -328,6 +502,28 @@ if [[ "${APPLY_CVE_2026_31431_PATCH}" == "1" ]]; then
         "${RPMBUILD}/SOURCES/${CVE_2026_31431_PATCH}"
 fi
 
+if [[ "${APPLY_DIRTYFRAG_ESP_PATCH}" == "1" ]]; then
+    echo ">>> Staging Dirty Frag ESP backport from ${SECURITY_DIR}..."
+    if [[ ! -f "${SECURITY_DIR}/${DIRTYFRAG_ESP_PATCH}" ]]; then
+        echo "ERROR: missing security patch ${SECURITY_DIR}/${DIRTYFRAG_ESP_PATCH}"
+        exit 1
+    fi
+    install -m 0644 \
+        "${SECURITY_DIR}/${DIRTYFRAG_ESP_PATCH}" \
+        "${RPMBUILD}/SOURCES/${DIRTYFRAG_ESP_PATCH}"
+fi
+
+if [[ "${APPLY_DIRTYFRAG_RXRPC_PATCH}" == "1" ]]; then
+    echo ">>> Staging Dirty Frag RxRPC backport from ${SECURITY_DIR}..."
+    if [[ ! -f "${SECURITY_DIR}/${DIRTYFRAG_RXRPC_PATCH}" ]]; then
+        echo "ERROR: missing security patch ${SECURITY_DIR}/${DIRTYFRAG_RXRPC_PATCH}"
+        exit 1
+    fi
+    install -m 0644 \
+        "${SECURITY_DIR}/${DIRTYFRAG_RXRPC_PATCH}" \
+        "${RPMBUILD}/SOURCES/${DIRTYFRAG_RXRPC_PATCH}"
+fi
+
 # --- Step 5: Copy base config ---
 echo ">>> Copying base config..."
 if [[ -f "${XR_DIR}/config/base.config" ]]; then
@@ -356,6 +552,8 @@ DEFINES=(
     --define "kversion ${KERNEL_VERSION}"
     --define "xr_release ${XR_RELEASE}"
     --define "apply_cve_2026_31431_patch ${APPLY_CVE_2026_31431_PATCH}"
+    --define "apply_dirtyfrag_esp_patch ${APPLY_DIRTYFRAG_ESP_PATCH}"
+    --define "apply_dirtyfrag_rxrpc_patch ${APPLY_DIRTYFRAG_RXRPC_PATCH}"
 )
 
 if [[ -n "${RT_VERSION}" ]]; then

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -14,6 +14,9 @@ CVE_2026_31431_MAINLINE_FIX="a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5"
 CVE_2026_31431_6_19_FIX="ce42ee423e58dffa5ec03524054c9d8bfd4f6237"
 CVE_2026_31431_6_18_FIX="fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8"
 CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
+DIRTYFRAG_ESP_FIX="f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"
+DIRTYFRAG_ESP_PATCH="dirtyfrag-esp-shared-frag.patch"
+DIRTYFRAG_RXRPC_PATCH="dirtyfrag-rxrpc-linearize.patch"
 
 BASE_REF="HEAD"
 UPSTREAM_REF=""
@@ -164,6 +167,18 @@ series_apply_status() {
 
 default_kernel_version() {
     sed -nE 's/^KERNEL_VERSION="([^"]+)"/\1/p' "${BUILD_SCRIPT}" | head -n 1
+}
+
+kernel_version_triplet() {
+    local version="$1"
+    local core major minor patch
+
+    core="${version%%-*}"
+    IFS=. read -r major minor patch _ <<< "${core}"
+    patch="${patch:-0}"
+
+    [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ && "${patch}" =~ ^[0-9]+$ ]] || return 1
+    echo "${major} ${minor} ${patch}"
 }
 
 cve_2026_31431_version_status() {
@@ -343,6 +358,151 @@ cve_2026_31431_build_route_status() {
     esac
 }
 
+security_patch_status() {
+    local patch="$1"
+
+    if [[ -f "${SECURITY_DIR}/${patch}" ]]; then
+        echo "present"
+    else
+        echo "missing"
+    fi
+}
+
+dirtyfrag_esp_version_status() {
+    local version="$1"
+    local major minor patch
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major == 7 && minor == 0 )); then
+        if (( patch >= 5 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
+    if (( major == 6 && (minor == 18 || minor == 19) )); then
+        echo "vulnerable"
+        return
+    fi
+
+    echo "unknown"
+}
+
+dirtyfrag_esp_repo_backport_applies() {
+    local version="$1"
+    local major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        return 1
+    fi
+
+    (( major == 6 && (minor == 18 || minor == 19) )) ||
+        (( major == 7 && minor == 0 && patch < 5 ))
+}
+
+dirtyfrag_esp_build_route_status() {
+    local version="$1"
+    local version_status
+
+    version_status="$(dirtyfrag_esp_version_status "${version}")"
+    case "${version_status}" in
+        fixed)
+            echo "fixed-base"
+            ;;
+        vulnerable)
+            if dirtyfrag_esp_repo_backport_applies "${version}"; then
+                if [[ "$(security_patch_status "${DIRTYFRAG_ESP_PATCH}")" == "present" ]]; then
+                    echo "repo-backport-applied-by-build"
+                else
+                    echo "backport-missing"
+                fi
+            else
+                echo "vulnerable"
+            fi
+            ;;
+        *)
+            echo "${version_status}"
+            ;;
+    esac
+}
+
+dirtyfrag_rxrpc_version_status() {
+    local version="$1"
+    local major minor patch
+
+    if [[ "${version}" == *-rc* ]]; then
+        echo "vulnerable"
+        return
+    fi
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        echo "unknown"
+        return
+    fi
+
+    if (( major == 7 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && (minor == 18 || minor == 19) )); then
+        echo "vulnerable"
+        return
+    fi
+
+    echo "unknown"
+}
+
+dirtyfrag_rxrpc_repo_backport_applies() {
+    local version="$1"
+    local major minor patch
+
+    [[ "${version}" != *-rc* ]] || return 1
+
+    if ! read -r major minor patch < <(kernel_version_triplet "${version}"); then
+        return 1
+    fi
+
+    (( major == 6 && (minor == 18 || minor == 19) )) ||
+        (( major == 7 && minor == 0 ))
+}
+
+dirtyfrag_rxrpc_build_route_status() {
+    local version="$1"
+    local version_status
+
+    version_status="$(dirtyfrag_rxrpc_version_status "${version}")"
+    case "${version_status}" in
+        vulnerable)
+            if dirtyfrag_rxrpc_repo_backport_applies "${version}"; then
+                if [[ "$(security_patch_status "${DIRTYFRAG_RXRPC_PATCH}")" == "present" ]]; then
+                    echo "repo-backport-applied-by-build"
+                else
+                    echo "backport-missing"
+                fi
+            else
+                echo "vulnerable"
+            fi
+            ;;
+        *)
+            echo "${version_status}"
+            ;;
+    esac
+}
+
 ref_contains_commit() {
     local ref="$1"
     local commit="$2"
@@ -456,6 +616,13 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo "| CVE-2026-31431 repo backport \`${CVE_2026_31431_PATCH}\` | \`$(cve_2026_31431_repo_backport_status)\` |"
     echo "| CVE-2026-31431 default build route | \`$(cve_2026_31431_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
     echo "| CVE-2026-31431 upstream/mainline fix \`${CVE_2026_31431_MAINLINE_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${CVE_2026_31431_MAINLINE_FIX}")\` |"
+    echo "| Dirty Frag ESP default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_esp_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| Dirty Frag ESP repo backport \`${DIRTYFRAG_ESP_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_ESP_PATCH}")\` |"
+    echo "| Dirty Frag ESP default build route | \`$(dirtyfrag_esp_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| Dirty Frag ESP upstream fix \`${DIRTYFRAG_ESP_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${DIRTYFRAG_ESP_FIX}")\` |"
+    echo "| Dirty Frag RxRPC default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_rxrpc_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| Dirty Frag RxRPC repo backport \`${DIRTYFRAG_RXRPC_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_RXRPC_PATCH}")\` |"
+    echo "| Dirty Frag RxRPC default build route | \`$(dirtyfrag_rxrpc_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
     if [[ "${#STABLE_REFS[@]}" -gt 0 ]]; then
         for stable_ref in "${STABLE_REFS[@]}"; do
             echo "| CVE-2026-31431 fix in candidate ref \`${stable_ref}\` | \`$(cve_2026_31431_ref_fix_status "${stable_ref}")\` |"
@@ -466,6 +633,7 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo
     echo "Known fixed floors for this gate include: \`5.10.254+\`, \`5.15.204+\`, \`6.1.170+\`, \`6.6.137+\`, \`6.12.85+\`, \`6.18.22+\`, \`6.19.12+\`, and \`7.0+\`."
     echo "For vulnerable \`6.19.x\` bases, \`build-rpm.sh\` applies the repo backport when present."
+    echo "Dirty Frag ESP is tracked as fixed in \`7.0.5+\` for the \`7.0.x\` lane; Dirty Frag RxRPC has no upstream fixed floor recorded here yet, so supported bases rely on the repo backport."
     echo
     echo "## Carry Apply Triage"
     echo
@@ -503,7 +671,7 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo
     echo "## Next Actions"
     echo
-    echo "1. Resolve any \`vulnerable\`, \`backport-missing\`, or \`unknown\` default build route before release work."
+    echo "1. Resolve any \`vulnerable\`, \`backport-missing\`, or \`unknown\` security build route before release work."
     echo "2. Inspect the upstream-only commit list for merge candidates or conflicts."
     echo "3. Check whether every patch in \`xr/patches/series\` still applies cleanly."
     echo "4. Build both generic and RT variants if the carry set is unchanged."

--- a/xr/security/README.md
+++ b/xr/security/README.md
@@ -10,6 +10,8 @@ feature carry; use `xr/patches/` for that path.
 | Patch | Source | Build behavior |
 | --- | --- | --- |
 | `cve-2026-31431-algif-aead.patch` | Linux stable `6.19.y` commit `ce42ee423e58`, backporting mainline `a664bf3d603d` | Applied automatically for vulnerable `6.19.x` bases before RT and XR carry patches |
+| `dirtyfrag-esp-shared-frag.patch` | Dirty Frag ESP mitigation from netdev/net commit `f4c50a4034e6` | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and pre-`7.0.5` `7.0.x` bases before RT and XR carry patches |
+| `dirtyfrag-rxrpc-linearize.patch` | linux-xr RXKAD backport adapted from the public Dirty Frag RxRPC patch route | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and `7.0.x` bases before RT and XR carry patches |
 
 Other affected kernel lines remain guarded by `xr/scripts/build-rpm.sh`, but do
 not have repo-managed backports here. Use a fixed upstream floor, vendor-fixed

--- a/xr/security/dirtyfrag-esp-shared-frag.patch
+++ b/xr/security/dirtyfrag-esp-shared-frag.patch
@@ -1,0 +1,30 @@
+diff --git a/net/ipv4/esp4.c b/net/ipv4/esp4.c
+index 2c922afadb8f6..ba3743ea78cb1 100644
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -873 +873,2 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index e4790cc7b5c2e..5bcd73cbdb41c 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -1235,0 +1236,2 @@ static int __ip_append_data(struct sock *sk,
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
+diff --git a/net/ipv6/esp6.c b/net/ipv6/esp6.c
+index e75da98f52838..116582d6985f2 100644
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -915 +915,2 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index 8e2a6b28cea7a..3f14e363c96e2 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -1767,0 +1768,2 @@ static int __ip6_append_data(struct sock *sk,
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;

--- a/xr/security/dirtyfrag-rxrpc-linearize.patch
+++ b/xr/security/dirtyfrag-rxrpc-linearize.patch
@@ -1,0 +1,25 @@
+diff --git a/net/rxrpc/rxkad.c b/net/rxrpc/rxkad.c
+index e923d6829008a..61ed01ae52509 100644
+--- a/net/rxrpc/rxkad.c
++++ b/net/rxrpc/rxkad.c
+@@ -570 +570 @@ static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
+-	struct rxrpc_skb_priv *sp = rxrpc_skb(skb);
++	struct rxrpc_skb_priv *sp;
+@@ -577 +577 @@ static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
+-	rxrpc_seq_t seq = sp->hdr.seq;
++	rxrpc_seq_t seq;
+@@ -582,3 +581,0 @@ static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
+-	_enter("{%d{%x}},{#%u}",
+-	       call->debug_id, key_serial(call->conn->key), seq);
+-
+@@ -587,0 +585,10 @@ static int rxkad_verify_packet(struct rxrpc_call *call, struct sk_buff *skb)
++	if (call->conn->security_level != RXRPC_SECURITY_PLAIN &&
++	    skb_linearize_cow(skb) < 0)
++		return -ENOMEM;
++
++	sp = rxrpc_skb(skb);
++	seq = sp->hdr.seq;
++
++	_enter("{%d{%x}},{#%u}",
++	       call->debug_id, key_serial(call->conn->key), seq);
++

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -19,6 +19,8 @@
 %{!?rt_version: %global rt_version %{nil}}
 %{!?variant: %global variant %{nil}}
 %{!?apply_cve_2026_31431_patch: %global apply_cve_2026_31431_patch 0}
+%{!?apply_dirtyfrag_esp_patch: %global apply_dirtyfrag_esp_patch 0}
+%{!?apply_dirtyfrag_rxrpc_patch: %global apply_dirtyfrag_rxrpc_patch 0}
 %if "%{variant}" == "-rt"
 %global actual_krel_regex ^%{kversion}-rt[^[:space:]]*-%{krelease}$
 %else
@@ -41,6 +43,12 @@ Patch0:         0007-vesa-dsc-bpp.patch
 Patch1:         bigscreen-beyond-edid.patch
 %if 0%{?apply_cve_2026_31431_patch}
 Patch2:         cve-2026-31431-algif-aead.patch
+%endif
+%if 0%{?apply_dirtyfrag_esp_patch}
+Patch3:         dirtyfrag-esp-shared-frag.patch
+%endif
+%if 0%{?apply_dirtyfrag_rxrpc_patch}
+Patch4:         dirtyfrag-rxrpc-linearize.patch
 %endif
 
 BuildRequires:  gcc
@@ -76,6 +84,12 @@ on AMD GPUs (RDNA2+). Includes:
 %if 0%{?apply_cve_2026_31431_patch}
 - CVE-2026-31431 algif_aead backport
 %endif
+%if 0%{?apply_dirtyfrag_esp_patch}
+- Dirty Frag ESP shared-frag hardening
+%endif
+%if 0%{?apply_dirtyfrag_rxrpc_patch}
+- Dirty Frag RxRPC RXKAD in-place decrypt hardening
+%endif
 %if "%{rt_version}" != ""
 - PREEMPT_RT real-time scheduling (%{rt_version})
 %endif
@@ -101,6 +115,12 @@ Userspace API header files for kernel-xr %{kversion}-%{krelease}.
 # Apply security backports before RT and XR carry patches.
 %if 0%{?apply_cve_2026_31431_patch}
 %patch -P2 -p1
+%endif
+%if 0%{?apply_dirtyfrag_esp_patch}
+%patch -P3 -p1
+%endif
+%if 0%{?apply_dirtyfrag_rxrpc_patch}
+%patch -P4 -p1
 %endif
 
 # Apply RT patch first (if building RT kernel)


### PR DESCRIPTION
## Summary

- add linux-xr DirtyFrag defensive backports for ESP shared-frag handling and RxRPC RXKAD in-place decrypt handling
- stage those backports as RPM spec patches and enforce DirtyFrag gates in xr/scripts/build-rpm.sh
- add cadence-report visibility and README/security-doc cross-links for DirtyFrag beside the existing Copy Fail / CVE-2026-31431 line

## Security posture

- v6.19.5-xr9 remains the secured Copy Fail / CVE-2026-31431 lab build.
- v6.19.5-xr9 should not be claimed as DirtyFrag-secured; DirtyFrag coverage requires a newer build from this branch or a base where upstream/vendor fixes are present.
- DirtyFrag ESP has a public upstream netdev fix; DirtyFrag RxRPC is carried here as a repo-managed defensive backport until an upstream fixed floor is recorded.

## Validation

- bash -n xr/scripts/build-rpm.sh
- bash -n xr/scripts/generate-cadence-report.sh
- git diff --check
- DirtyFrag/CVE preflight spot checks for 6.18.26, 6.19.5, 6.19.14, 7.0.3, and 7.0.5
- focused patch-application dry run against upstream 6.18.26, 6.19.5, 6.19.14, 7.0.3, and 7.0.5 source files
- nix flake check

Closes #47.
Refs #37.
