### PR TITLE
Add upstream target triage helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ kernel release build.
 - `nix develop` provides a shell with the core patch/report tooling.
 - `nix flake check` validates the patch series and shell-script syntax.
 - `nix run .#cadence-report -- --upstream-ref <ref> --stable-ref <ref>` runs the weekly cadence report helper from a repo checkout.
+- `nix run .#upstream-triage -- --run-preflight` discovers current stable/RT candidate floors and runs carry/security preflights.
 - `.github/workflows/determinate-ci.yml` pushes those lightweight flake outputs through Determinate CI / FlakeHub Cache.
 
 The real RPM release lane remains [`build-kernel.yml`](.github/workflows/build-kernel.yml) plus [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh) on Linux. Modeling the full kernel RPM build itself as a flake output is a separate, larger piece of work that should stay explicitly tracked.
@@ -255,6 +256,7 @@ Build optimizations:
 - Parallelism capped at `-j4` — prevents OOM on memory-constrained runners
 - ccache with `save-always: true` — warm builds ~1h vs cold ~2h
 - `weekly-cadence.yml` — fetches upstream plus maintained `linux-7.0.y` stable and `linux-6.18.y` longterm refs, renders a markdown report from `xr/patches/series`, checks carry patch application when full source paths are available, includes the current security watch, and opens a weekly cadence issue
+- `xr/scripts/triage-upstream-targets.sh` — discovers latest maintained generic and RT candidate floors from kernel.org and can run the bounded carry/security preflights used before source-sync promotion
 
 ## Version scheme
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
             set -euo pipefail
             bash -n "${self}/xr/scripts/build-rpm.sh"
             bash -n "${self}/xr/scripts/generate-cadence-report.sh"
+            bash -n "${self}/xr/scripts/triage-upstream-targets.sh"
             bash -n "${self}/xr/scripts/check-cve-2026-31431-live.sh"
             bash -n "${self}/xr/scripts/check-security-config.sh"
             bash -n "${self}/xr/scripts/check-kernel-carry.sh"
@@ -133,11 +134,34 @@
               exec bash "$repo_root/xr/scripts/generate-cadence-report.sh" "$@"
             '';
           };
+          upstreamTriage = pkgs.writeShellApplication {
+            name = "linux-xr-upstream-triage";
+            runtimeInputs = with pkgs; [
+              bash
+              coreutils
+              curl
+              gawk
+              git
+              gnugrep
+              gnused
+              gnutar
+              patch
+            ];
+            text = ''
+              set -euo pipefail
+              repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+              exec bash "$repo_root/xr/scripts/triage-upstream-targets.sh" "$@"
+            '';
+          };
         in
         {
           cadence-report = {
             type = "app";
             program = "${cadenceReport}/bin/linux-xr-cadence-report";
+          };
+          upstream-triage = {
+            type = "app";
+            program = "${upstreamTriage}/bin/linux-xr-upstream-triage";
           };
         });
 

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -4,7 +4,7 @@ title: Upstream Status
 
 # Upstream Status
 
-Baseline date: 2026-05-05
+Baseline date: 2026-05-08
 
 ## Carry Set
 
@@ -31,11 +31,10 @@ Carry order is defined in `xr/patches/series`.
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `8290ebb6f86d`
-- upstream `master` observed from kernel.org: `a293ec25d59d`
-- current mainline release candidate observed on kernel.org: `v7.1-rc2`
-- current stable observed on kernel.org: `v7.0.3`
-- current longterm candidates observed on kernel.org: `v6.18.26`, `v6.12.85`
+- linux-xr `xr/main`: `4add04b32ad3`
+- upstream `master` observed from GitHub: `917719c412c4`
+- current stable observed on kernel.org: `v7.0.5`
+- current longterm candidates observed on kernel.org: `v6.18.28`, `v6.12.87`
 - latest `6.19.y` stable tag observed on kernel.org: `v6.19.14` `[EOL]`
 
 The current RPM lane still builds the configured `6.19.5` tarball. Moving the
@@ -45,10 +44,13 @@ merge.
 `v6.19.14` remains a useful bounded compatibility proof because the generic
 linux-xr carry applies cleanly and the CVE security preflight passes, but it
 should not become the durable lab target now that kernel.org marks the line
-EOL. The maintained generic candidates checked on 2026-05-05 are `v7.0.3`
-stable and `v6.18.26` longterm; the carry dry-run and CVE security preflight
-passed for both. Keep RT pinned to the current `v6.19.5-xr9` line until a
-compatible RT patchset or local RT refresh is proven.
+EOL. The maintained generic candidates checked on 2026-05-08 are `v7.0.5`
+stable and `v6.18.28` longterm; the carry dry-run and security preflight passed
+for both. For RT, kernel.org currently exposes `patch-7.0.1-rt2` and
+`patch-6.18.13-rt4`; the `7.0.1-rt2` lane passed carry and security preflights,
+while `6.18.13-rt4` fails the CVE-2026-31431 gate. Keep RT pinned to the
+current `v6.19.5-xr9` line until a compatible RT patchset or local RT refresh
+is proven and promoted deliberately.
 
 ## Boundary Notes
 
@@ -102,3 +104,7 @@ The weekly maintenance intent is:
 4. promote only after host validation
 
 After merge, `.github/workflows/weekly-cadence.yml` is the repo's scheduled mechanism for producing that weekly report and opening a cadence issue.
+
+For ad hoc target selection, run `xr/scripts/triage-upstream-targets.sh` to
+discover current stable and RT floors, or add `--run-preflight` to execute the
+bounded carry/security checks before opening a source-sync branch.

--- a/xr/scripts/triage-upstream-targets.sh
+++ b/xr/scripts/triage-upstream-targets.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# triage-upstream-targets.sh - Discover maintained kernel targets and optionally
+# run linux-xr carry/security preflights against them.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+XR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_CARRY="${XR_DIR}/scripts/check-kernel-carry.sh"
+BUILD_RPM="${XR_DIR}/scripts/build-rpm.sh"
+
+STABLE_URL="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
+RT_BASE_URL="https://cdn.kernel.org/pub/linux/kernel/projects/rt"
+STABLE_FAMILIES=("7.0" "6.18" "6.12")
+RT_FAMILIES=("7.0" "6.18" "6.19")
+RUN_PREFLIGHT=0
+OUTPUT="-"
+
+usage() {
+    cat <<'EOF'
+Usage: triage-upstream-targets.sh [options]
+
+Options:
+  --run-preflight       Run carry and security preflights for discovered targets
+  --stable-family X.Y   Stable family to inspect; repeatable (default: 7.0, 6.18, 6.12)
+  --rt-family X.Y       RT patch family to inspect; repeatable (default: 7.0, 6.18, 6.19)
+  --output PATH         Output markdown file ('-' for stdout)
+  --help                Show this help
+
+The default mode is a network-backed report only. With --run-preflight, this
+script downloads source tarballs through check-kernel-carry.sh and may take
+several minutes per target.
+EOF
+}
+
+custom_stable_families=()
+custom_rt_families=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run-preflight)
+            RUN_PREFLIGHT=1
+            shift
+            ;;
+        --stable-family)
+            custom_stable_families+=("$2")
+            shift 2
+            ;;
+        --rt-family)
+            custom_rt_families+=("$2")
+            shift 2
+            ;;
+        --output)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "${#custom_stable_families[@]}" -gt 0 ]]; then
+    STABLE_FAMILIES=("${custom_stable_families[@]}")
+fi
+
+if [[ "${#custom_rt_families[@]}" -gt 0 ]]; then
+    RT_FAMILIES=("${custom_rt_families[@]}")
+fi
+
+require_command() {
+    local command="$1"
+
+    if ! command -v "${command}" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: ${command}" >&2
+        exit 1
+    fi
+}
+
+markdown_cell() {
+    local value="$1"
+
+    value="${value//$'\n'/ }"
+    value="${value//|/\\|}"
+    echo "${value}"
+}
+
+latest_stable_tag() {
+    local family="$1"
+
+    git ls-remote --tags "${STABLE_URL}" "refs/tags/v${family}.*" |
+        awk '{print $2}' |
+        sed 's#refs/tags/##; s/\^{}//' |
+        sort -Vu |
+        tail -n 1
+}
+
+latest_rt_patch() {
+    local family="$1"
+
+    curl -fsSL "${RT_BASE_URL}/${family}/" |
+        grep -Eo 'patch-[0-9][^"<> ]+\.patch\.xz' |
+        sort -Vu |
+        tail -n 1
+}
+
+rt_version_from_patch() {
+    local patch="$1"
+
+    patch="${patch#patch-}"
+    patch="${patch%.patch.xz}"
+    echo "${patch}"
+}
+
+kernel_version_from_rt_version() {
+    local rt_version="$1"
+
+    echo "${rt_version%-rt*}"
+}
+
+run_preflight() {
+    local log_file="$1"
+    shift
+
+    if "$@" >"${log_file}" 2>&1; then
+        echo "pass"
+    else
+        echo "fail"
+    fi
+}
+
+preflight_detail() {
+    local log_file="$1"
+
+    if [[ ! -s "${log_file}" ]]; then
+        echo "no output"
+        return
+    fi
+
+    tail -n 8 "${log_file}" |
+        sed -n '/^ERROR:/p; /^===/p; /^>>> Security preflight complete/p; /^patch: \*\*\*\*/p' |
+        tail -n 2 |
+        paste -sd ' ' -
+}
+
+require_command git
+require_command curl
+require_command awk
+require_command sed
+require_command sort
+require_command tail
+require_command paste
+
+if [[ "${RUN_PREFLIGHT}" == "1" ]]; then
+    require_command patch
+    require_command tar
+    [[ -x "${CHECK_CARRY}" ]] || chmod +x "${CHECK_CARRY}"
+    [[ -x "${BUILD_RPM}" ]] || chmod +x "${BUILD_RPM}"
+fi
+
+tmp_dir="$(mktemp -d)"
+tmp_report="$(mktemp)"
+trap 'rm -rf "${tmp_dir}" "${tmp_report}"' EXIT
+
+{
+    echo "# linux-xr Upstream Target Triage"
+    echo
+    echo "- Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    echo "- Stable source: \`${STABLE_URL}\`"
+    echo "- RT source: \`${RT_BASE_URL}\`"
+    echo "- Preflights: \`${RUN_PREFLIGHT}\`"
+    echo
+    echo "## Maintained Generic Candidates"
+    echo
+    echo "| Family | Latest tag | Kernel version | Carry dry-run | Security preflight | Detail |"
+    echo "| --- | --- | --- | --- | --- | --- |"
+
+    for family in "${STABLE_FAMILIES[@]}"; do
+        tag="$(latest_stable_tag "${family}" || true)"
+        version="${tag#v}"
+        carry_status="not-run"
+        security_status="not-run"
+        detail="run with --run-preflight"
+
+        if [[ -z "${tag}" ]]; then
+            version="unavailable"
+            detail="no matching stable tag found"
+        elif [[ "${RUN_PREFLIGHT}" == "1" ]]; then
+            carry_log="${tmp_dir}/generic-${version}-carry.log"
+            security_log="${tmp_dir}/generic-${version}-security.log"
+            carry_status="$(run_preflight "${carry_log}" "${CHECK_CARRY}" --kernel-version "${version}")"
+            security_status="$(run_preflight "${security_log}" "${BUILD_RPM}" --kernel-version "${version}" --xr-release 1 --security-preflight-only)"
+            detail="$(preflight_detail "${security_log}")"
+            if [[ -z "${detail}" ]]; then
+                detail="$(preflight_detail "${carry_log}")"
+            fi
+        fi
+
+        echo "| \`${family}.x\` | \`${tag:-unavailable}\` | \`${version}\` | \`${carry_status}\` | \`${security_status}\` | $(markdown_cell "${detail}") |"
+    done
+
+    echo
+    echo "## RT Patch Floors"
+    echo
+    echo "| Family | Latest RT patch | Kernel version | Carry + RT dry-run | Security preflight | Detail |"
+    echo "| --- | --- | --- | --- | --- | --- |"
+
+    for family in "${RT_FAMILIES[@]}"; do
+        patch_name="$(latest_rt_patch "${family}" || true)"
+        rt_version="unavailable"
+        version="unavailable"
+        carry_status="not-run"
+        security_status="not-run"
+        detail="run with --run-preflight"
+
+        if [[ -z "${patch_name}" ]]; then
+            patch_name="unavailable"
+            detail="no matching RT patch found"
+        else
+            rt_version="$(rt_version_from_patch "${patch_name}")"
+            version="$(kernel_version_from_rt_version "${rt_version}")"
+
+            if [[ "${RUN_PREFLIGHT}" == "1" ]]; then
+                carry_log="${tmp_dir}/rt-${rt_version}-carry.log"
+                security_log="${tmp_dir}/rt-${rt_version}-security.log"
+                carry_status="$(run_preflight "${carry_log}" "${CHECK_CARRY}" --kernel-version "${version}" --rt-version "${rt_version}")"
+                security_status="$(run_preflight "${security_log}" "${BUILD_RPM}" --kernel-version "${version}" --xr-release 1 --rt-version "${rt_version}" --security-preflight-only)"
+                detail="$(preflight_detail "${security_log}")"
+                if [[ -z "${detail}" ]]; then
+                    detail="$(preflight_detail "${carry_log}")"
+                fi
+            fi
+        fi
+
+        echo "| \`${family}.x\` | \`${patch_name}\` | \`${version}\` | \`${carry_status}\` | \`${security_status}\` | $(markdown_cell "${detail}") |"
+    done
+
+    echo
+    echo "## Next Actions"
+    echo
+    echo "1. Prefer the newest maintained generic candidate whose carry and security preflights pass."
+    echo "2. Treat RT as a separate lane when the newest stable tag and newest RT patch floor differ."
+    echo "3. Do not promote an older RT floor if the security preflight fails; port the missing security backport or keep RT pinned."
+} > "${tmp_report}"
+
+if [[ "${OUTPUT}" == "-" ]]; then
+    cat "${tmp_report}"
+else
+    install -m 0644 "${tmp_report}" "${OUTPUT}"
+fi

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,12 +5,14 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-05-05:
+As of 2026-05-08:
 
-- Current lab release line: `v6.19.5-xr9`
+- Current lab release line: `v6.19.5-xr10` is tagged and waiting on release artifacts
 - Bounded EOL compatibility proof target: `v6.19.14`
-- Maintained generic candidate targets: `v7.0.3` stable and `v6.18.26` longterm
-- RT blocker: `patch-6.19.3-rt1` does not apply to `v6.19.14`
+- Maintained generic candidate targets: `v7.0.5` stable and `v6.18.28` longterm
+- Longterm fallback watch: `v6.12.87`
+- RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
+- RT blockers: newest stable `v7.0.5` has no matching RT patch yet; `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13 backport
 
 Do not merge `torvalds/linux:master` into an active lab release branch. For the
 current lab line, source sync should target the selected maintained stable or
@@ -37,24 +39,33 @@ macOS case-insensitive checkouts for Linux source truth.
 Required checks before moving build defaults or release tags:
 
 ```bash
+# Discover current maintained candidates and optionally run bounded preflights:
+./xr/scripts/triage-upstream-targets.sh
+./xr/scripts/triage-upstream-targets.sh --run-preflight
+
 # Bounded EOL proof only:
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
 ./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only
 
 # Maintained candidate checks:
-./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.26
-./xr/scripts/build-rpm.sh --kernel-version 6.18.26 --xr-release 1 --security-preflight-only
-./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.3
-./xr/scripts/build-rpm.sh --kernel-version 7.0.3 --xr-release 1 --security-preflight-only
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.28
+./xr/scripts/build-rpm.sh --kernel-version 6.18.28 --xr-release 1 --security-preflight-only
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5
+./xr/scripts/build-rpm.sh --kernel-version 7.0.5 --xr-release 1 --security-preflight-only
 ```
 
 RT remains separate until a compatible RT patch is proven:
 
 ```bash
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.1 --rt-version 7.0.1-rt2
+./xr/scripts/build-rpm.sh --kernel-version 7.0.1 --xr-release 1 --rt-version 7.0.1-rt2 --security-preflight-only
 ```
 
-That RT command is expected to fail with the current RT patchset.
+The `6.19.14` RT command is expected to fail with the current `6.19.3-rt1`
+patchset. The `7.0.1-rt2` lane passed carry and security preflights on
+2026-05-08, but it is behind latest stable `7.0.5`; treat it as an RT floor
+candidate, not the generic SOTA target.
 
 ## Source-sync procedure
 


### PR DESCRIPTION
## Summary

- add `xr/scripts/triage-upstream-targets.sh` to discover current stable/longterm and RT patch floors from kernel.org
- wire the helper into the flake app surface as `nix run .#upstream-triage`
- refresh source-sync/upstream docs with the 2026-05-08 candidate posture: `v7.0.5`, `v6.18.28`, `v6.12.87`, and `7.0.1-rt2`

## Validation

- `bash -n xr/scripts/triage-upstream-targets.sh xr/scripts/generate-cadence-report.sh xr/scripts/build-rpm.sh xr/scripts/check-kernel-carry.sh`
- `git diff --check`
- `./xr/scripts/triage-upstream-targets.sh`
- `./xr/scripts/triage-upstream-targets.sh --run-preflight --stable-family 7.0 --rt-family 7.0`
- `nix flake check`
- `nix run .#upstream-triage -- --stable-family 7.0 --rt-family 7.0`

Refs: #37
Linear: TIN-976
