### PR TITLE
Guard headers install against stock kernel headers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,8 @@
             bash -n "${self}/xr/scripts/check-cve-2026-31431-live.sh"
             bash -n "${self}/xr/scripts/check-security-config.sh"
             bash -n "${self}/xr/scripts/check-kernel-carry.sh"
+            bash -n "${self}/site/install/rocky10-generic.sh"
+            bash -n "${self}/site/install/rocky10-rt.sh"
             mkdir -p "$out"
           '';
 

--- a/site/install.md
+++ b/site/install.md
@@ -34,4 +34,6 @@ For non-root validation or staged rollout work, both scripts also support:
 
 - The default runtime-only install avoids conflicts with Rocky's stock `kernel-headers` package on existing hosts.
 - `--no-set-default` captures the current default kernel and restores it after install if the package scriptlets change it.
-- The `--with-headers` flag is for development hosts that need UAPI headers and may require removing or replacing the stock `kernel-headers` package first.
+- The `--with-headers` flag is for development hosts that need UAPI headers.
+  The installer refuses that flag while Rocky's stock `kernel-headers` package
+  is installed because both packages own the same `/usr/include` UAPI paths.

--- a/site/install/rocky10-generic.sh
+++ b/site/install/rocky10-generic.sh
@@ -28,7 +28,7 @@ Options:
   --target-dir DIR    Directory to place downloaded RPMs in
   --no-set-default    Skip grubby default-kernel update after install
   --with-devel        Install the matching kernel-xr-devel RPM too
-  --with-headers      Install the matching kernel-xr-headers RPM too
+  --with-headers      Install kernel-xr-headers too; conflicts with stock kernel-headers
   --help              Show this help
 EOF
 }
@@ -52,6 +52,7 @@ need_cmd python3
 if (( PRINT_ASSETS == 0 && DOWNLOAD_ONLY == 0 )); then
     need_cmd sudo
     need_cmd dnf
+    need_cmd rpm
 fi
 
 WORKDIR="$(mktemp -d)"
@@ -171,6 +172,13 @@ fi
 
 if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
     echo "No installable generic RPMs found in ${DOWNLOAD_DIR}." >&2
+    exit 1
+fi
+
+if (( INSTALL_HEADERS == 1 )) && rpm -q kernel-headers >/dev/null 2>&1; then
+    echo "Refusing --with-headers because stock kernel-headers is installed." >&2
+    echo "kernel-xr-headers installs the same UAPI paths under /usr/include." >&2
+    echo "Remove or swap kernel-headers first, or rerun without --with-headers." >&2
     exit 1
 fi
 

--- a/site/install/rocky10-rt.sh
+++ b/site/install/rocky10-rt.sh
@@ -28,7 +28,7 @@ Options:
   --target-dir DIR    Directory to place downloaded RPMs in
   --no-set-default    Skip grubby default-kernel update after install
   --with-devel        Install the matching kernel-xr-rt-devel RPM too
-  --with-headers      Install the matching kernel-xr-rt-headers RPM too
+  --with-headers      Install kernel-xr-rt-headers too; conflicts with stock kernel-headers
   --help              Show this help
 EOF
 }
@@ -52,6 +52,7 @@ need_cmd python3
 if (( PRINT_ASSETS == 0 && DOWNLOAD_ONLY == 0 )); then
     need_cmd sudo
     need_cmd dnf
+    need_cmd rpm
 fi
 
 WORKDIR="$(mktemp -d)"
@@ -169,6 +170,13 @@ fi
 
 if [ "${#INSTALL_RPMS[@]}" -eq 0 ]; then
     echo "No installable RT RPMs found in ${DOWNLOAD_DIR}." >&2
+    exit 1
+fi
+
+if (( INSTALL_HEADERS == 1 )) && rpm -q kernel-headers >/dev/null 2>&1; then
+    echo "Refusing --with-headers because stock kernel-headers is installed." >&2
+    echo "kernel-xr-rt-headers installs the same UAPI paths under /usr/include." >&2
+    echo "Remove or swap kernel-headers first, or rerun without --with-headers." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- fail fast when `--with-headers` is requested while Rocky stock `kernel-headers` is installed
- document that `kernel-xr-headers` and stock `kernel-headers` own the same `/usr/include` UAPI paths
- include the public install scripts in the flake shell-syntax check

## Validation

- `bash -n site/install/rocky10-generic.sh site/install/rocky10-rt.sh`
- `git diff --check`
- `PAGES_BASE=https://tinyland-inc.github.io/linux-xr bash site/install/rocky10-generic.sh --print-assets`
- `PAGES_BASE=https://tinyland-inc.github.io/linux-xr bash site/install/rocky10-rt.sh --print-assets`
- `nix flake check`

Refs: #50
Linear: TIN-976
