### PR TITLE
docs: refresh DirtyFrag upstream triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ GitHub Release.
 Manual dispatch supports building a single variant:
 ```bash
 gh workflow run build-kernel.yml -f kernel_version=6.19.14 -f xr_release=1 -f variant=generic
-gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=9 -f variant=rt -f rt_version=6.19.3-rt1
-gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=9 -f variant=both -f rt_version=6.19.3-rt1
+gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=10 -f variant=rt -f rt_version=6.19.3-rt1
+gh workflow run build-kernel.yml -f kernel_version=6.19.5 -f xr_release=10 -f variant=both -f rt_version=6.19.3-rt1
 ```
 
 Build optimizations:
@@ -286,7 +286,7 @@ as needed. Unsupported vulnerable or unknown bases are refused unless
 For a no-build check of the active route:
 
 ```bash
-./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 9 --security-preflight-only
+./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 10 --security-preflight-only
 ```
 
 For a read-only check of a running host:
@@ -309,8 +309,8 @@ adding, dropping, or upstreaming a repo-managed CVE or public security backport.
 
 | CVE | Public name | linux-xr status | Repo links | External references |
 | --- | --- | --- | --- | --- |
-| CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` by carrying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
-| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | This repo adds repo-managed ESP and RxRPC backports for supported vulnerable `6.18.x`, `6.19.x`, and `7.0.x` RPM bases. `v6.19.5-xr9` is secured for Copy Fail, but Dirty Frag requires a newer linux-xr build from this repo state or an upstream/vendor-fixed base. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
+| CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` and carried forward in `v6.19.5-xr10` by applying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
+| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | `v6.19.5-xr10` carries repo-managed ESP and RxRPC backports on the vulnerable `6.19.5` base. Supported vulnerable `6.18.x`, `6.19.x`, and `7.0.x` RPM bases apply the relevant repo backports. `7.0.5` has the ESP fix natively, but still needs the linux-xr RxRPC carry; `6.12.87` has the ESP fix but remains blocked because linux-xr has no repo-managed `6.12` RxRPC backport route. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
 
 ## SELinux and Security Config
 
@@ -338,12 +338,13 @@ drift fails before an RPM can be accepted.
 
 ## Upstream status
 
-As of 2026-05-05, the latest published secured linux-xr lab release is
-[`v6.19.5-xr9`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr9).
-It keeps the `6.19.5` lab base but carries the repo-managed
-[`CVE-2026-31431`](#known-patched-cves-and-security-backports) backport.
-Dirty Frag is newer public security work and requires a newer linux-xr build
-from this branch or an upstream/vendor-fixed base. Kernel.org now lists
+As of 2026-05-09, the latest published secured linux-xr lab release is
+[`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10).
+It keeps the `6.19.5` lab base but carries repo-managed
+[`CVE-2026-31431`](#known-patched-cves-and-security-backports), Dirty Frag ESP,
+and Dirty Frag RxRPC backports. The generic `xr10` runtime is boot-proven on
+`mbp-13` and `honey`; RT artifacts are published but remain gated on explicit
+RT host validation. Kernel.org now lists
 `6.19.14` as EOL; it remains useful as a bounded compatibility proof, but it
 should not become the long-lived lab target. Issue
 [#37](https://github.com/tinyland-inc/linux-xr/issues/37) tracks rebasing the
@@ -356,28 +357,30 @@ Current ingestion checkpoint:
   patches in [`xr/patches/series`](xr/patches/series) dry-run cleanly against
   the `linux-6.19.14` tarball, and the security preflight passes by applying
   the repo-managed Dirty Frag backports.
-- Generic `6.18.26` longterm and `7.0.3` stable are maintained-base candidates:
+- Generic `6.18.28` longterm and `7.0.5` stable are maintained-base candidates:
   the XR carry patches dry-run cleanly against both tarballs, and the security
   preflight passes by applying the required repo-managed Dirty Frag backports.
-- RT cannot move to `6.19.14` with the current `6.19.3-rt1` patchset: that RT
-  patch fails to dry-run against `6.19.14` in the `8250_port.c` serial driver
-  path. Keep the current RT artifact line on `v6.19.5-xr9` until a compatible
-  RT patchset or local RT refresh is proven. The visible kernel.org 6.19 RT
-  directory still only exposes `patch-6.19.3-rt1`.
+- Generic `6.12.87` is not a linux-xr fallback yet: the tarball has the ESP
+  shared-frag hardening, but the DSC carry conflicts and Dirty Frag RxRPC has
+  no repo-managed `6.12` backport route.
+- RT `7.0.1-rt2` and `6.19.3-rt1` pass the bounded carry/security preflights;
+  RT `6.18.13-rt4` still fails the CVE-2026-31431 gate. Keep RT promotion
+  separate from the generic SOTA target until a same-base RT patchset or local
+  RT refresh is proven.
 - Use [`xr/scripts/check-kernel-carry.sh`](xr/scripts/check-kernel-carry.sh) to
   repeat this check before bumping build defaults or tagging a release.
 
 ```bash
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
-./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.26
-./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.3
-./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.28
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.1 --rt-version 7.0.1-rt2
 ```
 
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
-| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr9` carries the `6.19.y` backport on the current `6.19.5` lab base | Boot/install validate `xr9` on lab hosts, then rebase the generic lane to a maintained target such as `7.0.3` stable or `6.18.26` longterm under issue #37. Treat 6.12-class stock hosts as exposed unless a vendor backport or mitigation is proven. |
-| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; RxRPC still needs explicit tracking because the public write-up reports no upstream fix at disclosure time | Build and publish a new linux-xr RPM with both Dirty Frag backports for `6.19.x`; keep `7.0.x` source-sync candidates gated until the RxRPC fix is upstream or carried locally. |
+| CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr10` carries the `6.19.y` backport on the current `6.19.5` lab base | Keep fleet rollout on `xr10`, then rebase the generic lane to a maintained target such as `7.0.5` stable or `6.18.28` longterm under issue #37. Treat stock 6.12-class hosts as exposed to Dirty Frag RxRPC unless a vendor backport, mitigation, or linux-xr route is proven. |
+| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; the `6.12.87` tarball also has ESP hardening; RxRPC still needs explicit tracking because no `skb_linearize_cow()` RxRPC hardening was observed in Linus `master` or checked stable branch heads | Keep `v6.19.5-xr10` as the current secured lab release, keep carrying RxRPC on source-sync candidates until upstream/vendor fixed floors are proven, and leave `6.12.87` blocked until DSC carry and RxRPC routing are resolved. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -4,7 +4,7 @@ title: Upstream Status
 
 # Upstream Status
 
-Baseline date: 2026-05-08
+Baseline date: 2026-05-09
 
 ## Carry Set
 
@@ -31,15 +31,16 @@ Carry order is defined in `xr/patches/series`.
 
 ## Current Upstream Snapshot
 
-- linux-xr `xr/main`: `4add04b32ad3`
-- upstream `master` observed from GitHub: `917719c412c4`
+- linux-xr `xr/main`: `db6d3bd67436`
+- upstream `master` observed from kernel.org: `27a26ccfd528`
 - current stable observed on kernel.org: `v7.0.5`
 - current longterm candidates observed on kernel.org: `v6.18.28`, `v6.12.87`
 - latest `6.19.y` stable tag observed on kernel.org: `v6.19.14` `[EOL]`
 
-The current RPM lane still builds the configured `6.19.5` tarball. Moving the
-release lane forward should be a deliberate cadence item, not an incidental
-merge.
+The current RPM lane still builds the configured `6.19.5` tarball, now secured
+by repo-managed CVE-2026-31431 and Dirty Frag backports in the published
+`v6.19.5-xr10` release. Moving the source-sync lane forward should be a
+deliberate cadence item, not an incidental merge.
 
 `v6.19.14` remains a useful bounded compatibility proof because the generic
 linux-xr carry applies cleanly and the CVE security preflight passes, but it
@@ -51,6 +52,19 @@ for both. For RT, kernel.org currently exposes `patch-7.0.1-rt2` and
 while `6.18.13-rt4` fails the CVE-2026-31431 gate. Keep RT pinned to the
 current `v6.19.5-xr9` line until a compatible RT patchset or local RT refresh
 is proven and promoted deliberately.
+
+On the Dirty Frag front, Linus `master` now contains the ESP shared-frag fix as
+`f4c50a4034e6`. Current stable branch heads for `7.0.y`, `6.18.y`, and
+`6.12.y` also contain an equivalent ESP hardening commit, but the EOL `6.19.y`
+branch head does not. No `skb_linearize_cow()` RxRPC hardening was observed in
+`net/rxrpc/rxkad.c` on Linus `master` or the checked stable branch heads, so the
+linux-xr Dirty Frag RxRPC carry remains required for supported release bases.
+
+`v6.12.87` remains blocked as a linux-xr fallback: the tarball has the ESP
+shared-frag hardening, but the DSC carry conflicts and the RxRPC hardening has
+no repo-managed `6.12` backport route. The upstream triage helper now reports
+carry and security failures independently so this class of mixed failure stays
+visible.
 
 ## Boundary Notes
 

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -244,6 +244,15 @@ dirtyfrag_esp_status() {
         return
     fi
 
+    if (( major == 6 && minor == 12 )); then
+        if (( patch >= 87 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
     if (( major == 6 && (minor == 18 || minor == 19) )); then
         echo "vulnerable"
         return
@@ -286,6 +295,11 @@ dirtyfrag_rxrpc_status() {
     fi
 
     if (( major == 7 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 12 )); then
         echo "vulnerable"
         return
     fi

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -391,6 +391,15 @@ dirtyfrag_esp_version_status() {
         return
     fi
 
+    if (( major == 6 && minor == 12 )); then
+        if (( patch >= 87 )); then
+            echo "fixed"
+        else
+            echo "vulnerable"
+        fi
+        return
+    fi
+
     if (( major == 6 && (minor == 18 || minor == 19) )); then
         echo "vulnerable"
         return
@@ -454,6 +463,11 @@ dirtyfrag_rxrpc_version_status() {
     fi
 
     if (( major == 7 && minor == 0 )); then
+        echo "vulnerable"
+        return
+    fi
+
+    if (( major == 6 && minor == 12 )); then
         echo "vulnerable"
         return
     fi

--- a/xr/scripts/triage-upstream-targets.sh
+++ b/xr/scripts/triage-upstream-targets.sh
@@ -143,10 +143,40 @@ preflight_detail() {
         return
     fi
 
-    tail -n 8 "${log_file}" |
-        sed -n '/^ERROR:/p; /^===/p; /^>>> Security preflight complete/p; /^patch: \*\*\*\*/p' |
+    tail -n 20 "${log_file}" |
+        sed -n \
+            -e '/^ERROR:/p' \
+            -e '/^===/p' \
+            -e '/^>>> Security preflight complete/p' \
+            -e '/^patch: \*\*\*\*/p' \
+            -e '/hunk.*failed/p' \
+            -e '/out of .*hunks.*failed/p' \
+            -e '/malformed patch/p' \
+            -e "/can't find file/p" |
         tail -n 2 |
         paste -sd ' ' -
+}
+
+combined_preflight_detail() {
+    local carry_status="$1"
+    local carry_log="$2"
+    local security_status="$3"
+    local security_log="$4"
+    local carry_detail
+    local security_detail
+
+    carry_detail="$(preflight_detail "${carry_log}")"
+    security_detail="$(preflight_detail "${security_log}")"
+
+    if [[ "${carry_status}" == "pass" && "${security_status}" == "pass" ]]; then
+        echo "carry pass; security pass"
+    elif [[ "${carry_status}" != "pass" && "${security_status}" != "pass" ]]; then
+        echo "carry: ${carry_detail:-failed}; security: ${security_detail:-failed}"
+    elif [[ "${carry_status}" != "pass" ]]; then
+        echo "carry: ${carry_detail:-failed}"
+    else
+        echo "security: ${security_detail:-failed}"
+    fi
 }
 
 require_command git
@@ -196,10 +226,7 @@ trap 'rm -rf "${tmp_dir}" "${tmp_report}"' EXIT
             security_log="${tmp_dir}/generic-${version}-security.log"
             carry_status="$(run_preflight "${carry_log}" "${CHECK_CARRY}" --kernel-version "${version}")"
             security_status="$(run_preflight "${security_log}" "${BUILD_RPM}" --kernel-version "${version}" --xr-release 1 --security-preflight-only)"
-            detail="$(preflight_detail "${security_log}")"
-            if [[ -z "${detail}" ]]; then
-                detail="$(preflight_detail "${carry_log}")"
-            fi
+            detail="$(combined_preflight_detail "${carry_status}" "${carry_log}" "${security_status}" "${security_log}")"
         fi
 
         echo "| \`${family}.x\` | \`${tag:-unavailable}\` | \`${version}\` | \`${carry_status}\` | \`${security_status}\` | $(markdown_cell "${detail}") |"
@@ -231,10 +258,7 @@ trap 'rm -rf "${tmp_dir}" "${tmp_report}"' EXIT
                 security_log="${tmp_dir}/rt-${rt_version}-security.log"
                 carry_status="$(run_preflight "${carry_log}" "${CHECK_CARRY}" --kernel-version "${version}" --rt-version "${rt_version}")"
                 security_status="$(run_preflight "${security_log}" "${BUILD_RPM}" --kernel-version "${version}" --xr-release 1 --rt-version "${rt_version}" --security-preflight-only)"
-                detail="$(preflight_detail "${security_log}")"
-                if [[ -z "${detail}" ]]; then
-                    detail="$(preflight_detail "${carry_log}")"
-                fi
+                detail="$(combined_preflight_detail "${carry_status}" "${carry_log}" "${security_status}" "${security_log}")"
             fi
         fi
 

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,12 +5,15 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-05-08:
+As of 2026-05-09:
 
-- Current lab release line: `v6.19.5-xr10` is tagged and waiting on release artifacts
+- Current lab release line: `v6.19.5-xr10` is published and boot-proven on
+  `mbp-13` and `honey`
 - Bounded EOL compatibility proof target: `v6.19.14`
 - Maintained generic candidate targets: `v7.0.5` stable and `v6.18.28` longterm
-- Longterm fallback watch: `v6.12.87`
+- Longterm fallback watch: `v6.12.87`, currently blocked for linux-xr because
+  the DSC carry conflicts and Dirty Frag RxRPC has no repo-managed `6.12`
+  backport route
 - RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
 - RT blockers: newest stable `v7.0.5` has no matching RT patch yet; `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13 backport
 
@@ -53,6 +56,11 @@ Required checks before moving build defaults or release tags:
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5
 ./xr/scripts/build-rpm.sh --kernel-version 7.0.5 --xr-release 1 --security-preflight-only
 ```
+
+The `6.12.87` tarball contains the ESP shared-frag hardening, but the
+`rxkad.c` tree does not contain the Dirty Frag RxRPC linearize/COW hardening.
+Do not use `6.12.87` as a linux-xr fallback unless the DSC carry is refreshed
+and the RxRPC security route is resolved.
 
 RT remains separate until a compatible RT patch is proven:
 


### PR DESCRIPTION
## Summary

- clarify that `v6.19.5-xr10` is the current secured lab release and boot-proven on mbp-13 and honey
- classify DirtyFrag ESP/RxRPC status across current source-sync candidates, including the 6.12.87 RxRPC blocker
- improve upstream target triage so carry and security failures are reported independently
- teach the DirtyFrag gate that 6.12.87 has ESP hardening but still fails because RxRPC has no linux-xr 6.12 route

## Validation

- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh xr/scripts/triage-upstream-targets.sh`
- `git diff --check`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 10 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.12.87 --xr-release 1 --security-preflight-only` fails as expected on DirtyFrag RxRPC
- `./xr/scripts/triage-upstream-targets.sh --run-preflight --stable-family 6.12 --rt-family 6.18`
