### PR TITLE
[codex] Refresh honey xr10 site state

### DIFF
--- a/site/docs/honey.md
+++ b/site/docs/honey.md
@@ -19,13 +19,19 @@ This repo owns C0 supplier facts: the generic and RT kernel RPMs, install
 surface, carry patch set, and release cadence. It does not own SMI, NUMA,
 Chapel, C-state, reset, or workstation acceptance evidence.
 
-Historical rollout evidence from the 2026-04-12 validation:
-
 Current known supplier-side state:
 
-- running kernel: `6.19.5-7.xr.el10`
-- saved default boot kernel: `/boot/vmlinuz-6.19.5-7.xr.el10`
-- installed generic XR runtime RPM: `kernel-xr-6.19.5-7.xr.el10`
+- running kernel: `6.19.5-10.xr.el10`
+- installed generic XR runtime RPMs: `kernel-xr-6.19.5-7.xr.el10`,
+  `kernel-xr-6.19.5-9.xr.el10`, and `kernel-xr-6.19.5-10.xr.el10`
+- installed devel RPM: `kernel-xr-devel-6.19.5-10.xr.el10`
+- rollback generic kernels remain installed: `6.19.5-9.xr.el10` and
+  `6.19.5-7.xr.el10`
+- Secure Boot is disabled
+- sudo requires an interactive password on this host
+
+Historical rollout evidence from the 2026-04-12 validation:
+
 - installed RT XR runtime RPM: `kernel-xr-rt-6.19.5-8.xr.el10`
 - RT boot into `6.19.5-rt1-8.xr.el10` succeeded
 - live RT verification on `honey` confirmed `uname -v` contains `PREEMPT_RT` and `/sys/kernel/realtime` is `1`
@@ -33,7 +39,6 @@ Current known supplier-side state:
 - OpenXR userspace present
 - Monado unit files present but disabled
 - DRM nodes present on both the generic and RT validation boots
-- sudo requires an interactive password on this host
 
 Current live host posture is not owned by this page. Dell-7810 is the authority
 for `honey`'s current booted kernel, BIOS/SMI state, tuned profile, and reset
@@ -43,7 +48,8 @@ posture.
 
 Rollout stance:
 
-- generic XR kernel: active, documented, and the persistent default
+- generic XR kernel: active, documented, and boot-proven on the secured
+  `v6.19.5-xr10` line
 - RT XR kernel: reboot-valid and functionally verified, but still gated for regular use. Dell's repeated host packet is cautionary rather than improved, so regular RT use needs a downstream deadline packet, not only kernel boot proof.
 
 For live `honey` host state and current RT acceptance, see:

--- a/site/docs/upstream-status.md
+++ b/site/docs/upstream-status.md
@@ -50,7 +50,7 @@ stable and `v6.18.28` longterm; the carry dry-run and security preflight passed
 for both. For RT, kernel.org currently exposes `patch-7.0.1-rt2` and
 `patch-6.18.13-rt4`; the `7.0.1-rt2` lane passed carry and security preflights,
 while `6.18.13-rt4` fails the CVE-2026-31431 gate. Keep RT pinned to the
-current `v6.19.5-xr9` line until a compatible RT patchset or local RT refresh
+current `v6.19.5-xr10` line until a compatible RT patchset or local RT refresh
 is proven and promoted deliberately.
 
 On the Dirty Frag front, Linus `master` now contains the ESP shared-frag fix as

--- a/site/install.md
+++ b/site/install.md
@@ -13,7 +13,7 @@ curl -fsSL https://tinyland-inc.github.io/linux-xr/install/rocky10-rt.sh | bash
 
 The scripts download the latest installable lab release assets, install the runtime kernel RPM by default, try to set the newest matching XR kernel as default, and print the expected post-reboot verification command.
 
-The public `latest.json` manifest is regenerated from the newest non-draft installable `vX.Y.Z-xrN` release with both generic and RT runtime RPMs. This intentionally includes secured lab prereleases such as `v6.19.5-xr9`, while excluding proof-only releases such as `proof-6.19.14-xr1-generic` and `proof-7.0.3-xr1-generic`.
+The public `latest.json` manifest is regenerated from the newest non-draft installable `vX.Y.Z-xrN` release with both generic and RT runtime RPMs. This intentionally includes secured lab prereleases such as `v6.19.5-xr10`, while excluding proof-only releases such as `proof-6.19.14-xr1-generic` and `proof-7.0.3-xr1-generic`.
 
 For non-root validation or staged rollout work, both scripts also support:
 


### PR DESCRIPTION
## Summary

- refresh the public honey page with the read-only verified `6.19.5-10.xr.el10` state
- update install/upstream docs that still named xr9 as the current secured installable or RT-pinned line

## Validation

- `git diff --check`
- `nix flake check`

## Notes

The live host probe was read-only. It verified honey and mbp-13 on generic `6.19.5-10.xr.el10`; sting remains on `6.19.5-9.xr.el10`; yoga is offline in Tailscale.