### PR TITLE
[codex] Keep cadence stable fetch branch-only

### DIFF
--- a/.github/workflows/weekly-cadence.yml
+++ b/.github/workflows/weekly-cadence.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Fetch upstream refs
         run: |
           git fetch --no-tags --prune https://github.com/torvalds/linux.git master:refs/remotes/upstream/master
-          git fetch --tags --prune https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git \
+          git fetch --no-tags --prune https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git \
             linux-7.0.y:refs/remotes/stable/linux-7.0.y \
             linux-6.18.y:refs/remotes/longterm/linux-6.18.y
 

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -9,6 +9,7 @@ PATCH_DIR="${XR_DIR}/patches"
 SERIES_FILE="${PATCH_DIR}/series"
 BUILD_SCRIPT="${XR_DIR}/scripts/build-rpm.sh"
 SECURITY_DIR="${XR_DIR}/security"
+STABLE_URL="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
 
 CVE_2026_31431_MAINLINE_FIX="a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5"
 CVE_2026_31431_6_19_FIX="ce42ee423e58dffa5ec03524054c9d8bfd4f6237"
@@ -63,6 +64,47 @@ short_ref() {
 
 describe_ref() {
     git describe --tags --abbrev=0 "$1" 2>/dev/null || echo "unavailable"
+}
+
+stable_family_from_ref() {
+    local ref="$1"
+
+    if [[ "${ref}" =~ linux-([0-9]+\.[0-9]+)\.y ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    if [[ "${ref}" =~ v([0-9]+\.[0-9]+)\. ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    return 1
+}
+
+latest_stable_tag_for_ref() {
+    local ref="$1"
+    local described
+    local family
+    local tag
+
+    if family="$(stable_family_from_ref "${ref}")"; then
+        tag="$(
+            { git ls-remote --tags "${STABLE_URL}" "refs/tags/v${family}.*" 2>/dev/null || true; } |
+                awk '{print $2}' |
+                sed 's#refs/tags/##; s/\^{}//' |
+                sort -Vu |
+                tail -n 1
+        )"
+
+        if [[ -n "${tag}" ]]; then
+            echo "${tag}"
+            return
+        fi
+    fi
+
+    described="$(describe_ref "${ref}")"
+    echo "${described}"
 }
 
 commit_list() {
@@ -673,7 +715,7 @@ trap 'rm -f "${tmp_report}"' EXIT
     if [[ "${#STABLE_REFS[@]}" -gt 0 ]]; then
         for stable_ref in "${STABLE_REFS[@]}"; do
             if has_ref "${stable_ref}"; then
-                echo "- Candidate ref: \`${stable_ref}\` (\`$(short_ref "${stable_ref}")\`), latest tag \`$(describe_ref "${stable_ref}")\`"
+                echo "- Candidate ref: \`${stable_ref}\` (\`$(short_ref "${stable_ref}")\`), latest tag \`$(latest_stable_tag_for_ref "${stable_ref}")\`"
             else
                 echo "- Candidate ref unavailable: \`${stable_ref}\`"
             fi


### PR DESCRIPTION
## Summary
- switch the weekly cadence stable fetch from all-tags to branch-only refs
- teach the cadence report to discover latest stable tags from kernel.org by family
- avoid the multi-million-object tag fetch path while preserving current target reporting

## Validation
- bash -n xr/scripts/generate-cadence-report.sh
- git diff --check
- bash xr/scripts/generate-cadence-report.sh --base-ref HEAD --stable-ref refs/remotes/stable/linux-7.0.y --stable-ref refs/remotes/longterm/linux-6.18.y --skip-patch-triage --max-commits 3
- nix flake check
- nix flake check --system x86_64-linux

Note: nix flake check --all-systems could not complete locally because no aarch64-linux builder was available; x86_64-linux and default local-platform checks passed.