### PR TITLE
[codex] Pin owned checkout actions to Node 24 release

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Checkout
         if: steps.filter.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           filter: blob:none
           sparse-checkout: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Sync repository labels
         uses: actions/github-script@v7

--- a/.github/workflows/weekly-cadence.yml
+++ b/.github/workflows/weekly-cadence.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- updates owned workflow `actions/checkout` pins from `v4` to `v6.0.2`
- moves direct linux-xr checkout usage onto the Node 24 release line ahead of the Node 20 runner retirement window
- keeps the change scoped to checkout only; other action upgrades remain separate behavior changes

## Notes
- Determinate CI itself is a reusable workflow from `DeterminateSystems/ci/.github/workflows/workflow.yml@main` and still invokes `actions/checkout@v4` internally as of the PR run. This PR does not vendor or replace that external workflow.
- Keep linux-xr#39 open after merge until the external reusable workflow is Node 24-ready or we intentionally replace it with an owned workflow.

## Validation
- `git diff --check`
- `bash -n xr/scripts/generate-cadence-report.sh xr/scripts/triage-upstream-targets.sh xr/scripts/build-rpm.sh xr/scripts/check-security-config.sh xr/scripts/check-kernel-carry.sh`
- `nix flake check`
- `nix flake check --system x86_64-linux`
