### PR TITLE
[codex] Own Determinate CI workflow for Node 24 checkout

### DIFF
--- a/.github/workflows/determinate-ci.yml
+++ b/.github/workflows/determinate-ci.yml
@@ -8,12 +8,82 @@ on:
       - xr/main
 
 jobs:
-  determinate-ci:
+  inventory:
+    name: determinate-ci / inventory
     # This caches and validates the thin Nix surface for linux-xr. It is not
     # the canonical kernel RPM release lane, which remains the Rocky/Linux
     # workflow in build-kernel.yml. Do not opt into FlakeHub publishing here:
     # this repository is a kernel tree and exceeds FlakeHub's archive limit.
-    uses: DeterminateSystems/ci/.github/workflows/workflow.yml@main
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+    outputs:
+      systems: ${{ steps.inventory.outputs.systems }}
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: DeterminateSystems/determinate-nix-action@v3
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Inventory the flake for targeted systems
+        id: inventory
+        env:
+          FLAKE_ITER_FLAKEREF: https://flakehub.com/f/DeterminateSystems/flake-iter/*
+          FLAKE_ITER_RUNNER_MAP: |
+            {
+              "aarch64-darwin": "macos-latest",
+              "x86_64-linux": "ubuntu-latest",
+              "aarch64-linux": "ubuntu-24.04-arm"
+            }
+        run: nix run "$FLAKE_ITER_FLAKEREF" -- systems
+
+  build:
+    name: determinate-ci / build (${{ matrix.systems.nix-system }}, ${{ matrix.systems.runner }})
+    needs: inventory
+    runs-on: ${{ matrix.systems.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        systems: ${{ fromJSON(needs.inventory.outputs.systems) }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            extra-experimental-features = provenance
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Build for ${{ matrix.systems.nix-system }}
+        env:
+          FLAKE_ITER_FLAKEREF: https://flakehub.com/f/DeterminateSystems/flake-iter/*
+          FLAKE_ITER_NIX_SYSTEM: ${{ matrix.systems.nix-system }}
+        run: nix run "$FLAKE_ITER_FLAKEREF" -- --verbose build
+
+  success:
+    name: determinate-ci / success
+    needs: build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - run: "true"
+
+      - name: Fail if any build job failed
+        if: |
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A dependent in the build matrix failed."
+          exit 1


### PR DESCRIPTION
## Summary
- replaces the external `DeterminateSystems/ci/.github/workflows/workflow.yml@main` reusable workflow call with an owned workflow
- preserves the existing inventory, per-system build matrix, and aggregate success check names
- pins the owned checkout steps to `actions/checkout@v6.0.2` so linux-xr no longer depends on external `checkout@v4` usage for Determinate CI

## Why
PR #56 fixed direct checkout pins in the other linux-xr workflows, but live CI still showed Node 20 annotations from the external Determinate reusable workflow. Owning this small workflow removes that external `checkout@v4` path without contacting upstream or waiting on another org.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/determinate-ci.yml"); puts "yaml ok"'
- `git diff --check`
- `rg -n "actions/checkout@v4|DeterminateSystems/ci|actions/checkout@v6\\.0\\.2" .github/workflows/determinate-ci.yml .github/workflows`
- `nix flake check --system x86_64-linux`

Note: `actionlint` is not installed locally, so GitHub Actions is the authoritative workflow validation for this PR.
