### PR TITLE
carry: make DSC patch apply to 6.12

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 *.[ch] diff=cpp
 *.dts diff=dts
 *.dts[io] diff=dts
+*.patch whitespace=-space-before-tab,-blank-at-eol
 *.rs diff=rust

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ adding, dropping, or upstreaming a repo-managed CVE or public security backport.
 | CVE | Public name | linux-xr status | Repo links | External references |
 | --- | --- | --- | --- | --- |
 | CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` and carried forward in `v6.19.5-xr10` by applying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
-| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | `v6.19.5-xr10` carries repo-managed ESP and RxRPC backports on the vulnerable `6.19.5` base. Supported vulnerable `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` RPM bases apply the relevant repo backports. `7.0.5` has the ESP fix natively, but still needs the linux-xr RxRPC carry; `6.12.87` has ESP fixed natively and now has a linux-xr RxRPC build route, but remains blocked by XR DSC carry conflicts. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
+| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | `v6.19.5-xr10` carries repo-managed ESP and RxRPC backports on the vulnerable `6.19.5` base. Supported vulnerable `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` RPM bases apply the relevant repo backports. `7.0.5` has the ESP fix natively, but still needs the linux-xr RxRPC carry; `6.12.87` has ESP fixed natively, a linux-xr RxRPC build route, and a DSC carry dry-run route, but still needs an RPM proof before fallback promotion. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
 
 ## SELinux and Security Config
 
@@ -360,9 +360,10 @@ Current ingestion checkpoint:
 - Generic `6.18.28` longterm and `7.0.5` stable are maintained-base candidates:
   the XR carry patches dry-run cleanly against both tarballs, and the security
   preflight passes by applying the required repo-managed Dirty Frag backports.
-- Generic `6.12.87` is not a linux-xr fallback yet: the tarball has the ESP
-  shared-frag hardening and the repo-managed Dirty Frag RxRPC route applies,
-  but the DSC carry conflicts.
+- Generic `6.12.87` now passes bounded carry and security preflight: the
+  tarball has the ESP shared-frag hardening, the repo-managed Dirty Frag RxRPC
+  route applies, and the DSC carry has a 6.12-compatible dry-run path. Keep it
+  as a fallback candidate until a real RPM proof succeeds.
 - RT `7.0.1-rt2` and `6.19.3-rt1` pass the bounded carry/security preflights;
   RT `6.18.13-rt4` still fails the CVE-2026-31431 gate. Keep RT promotion
   separate from the generic SOTA target until a same-base RT patchset or local
@@ -373,6 +374,7 @@ Current ingestion checkpoint:
 ```bash
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.28
+./xr/scripts/check-kernel-carry.sh --kernel-version 6.12.87
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.1 --rt-version 7.0.1-rt2
 ```
@@ -380,7 +382,7 @@ Current ingestion checkpoint:
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
 | CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr10` carries the `6.19.y` backport on the current `6.19.5` lab base | Keep fleet rollout on `xr10`, then rebase the generic lane to a maintained target such as `7.0.5` stable or `6.18.28` longterm under issue #37. Treat stock 6.12-class hosts as exposed to Dirty Frag RxRPC unless a vendor backport, mitigation, or linux-xr route is proven and installed. |
-| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; the `6.12.87` tarball also has ESP hardening; RxRPC still needs explicit tracking because no `skb_linearize_cow()` RxRPC hardening was observed in Linus `master` or checked stable branch heads | Keep `v6.19.5-xr10` as the current secured lab release, keep carrying RxRPC on source-sync candidates until upstream/vendor fixed floors are proven, and leave `6.12.87` blocked until the DSC carry conflict is resolved. |
+| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; the `6.12.87` tarball also has ESP hardening; RxRPC still needs explicit tracking because no `skb_linearize_cow()` RxRPC hardening was observed in Linus `master` or checked stable branch heads | Keep `v6.19.5-xr10` as the current secured lab release, keep carrying RxRPC on source-sync candidates until upstream/vendor fixed floors are proven, and treat `6.12.87` as a fallback candidate only after an RPM proof succeeds. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/xr/patches/0007-vesa-dsc-bpp.map.md
+++ b/xr/patches/0007-vesa-dsc-bpp.map.md
@@ -27,6 +27,22 @@ until measured evidence justifies submitting or retaining them.
 | QP table correction | `drivers/gpu/drm/amd/display/dc/dml/dsc/qp_tables.h` | local-risk carry | Changes min/max QP table entries for 8bpc 4:4:4. This is not part of the v7 upstream DSC-BPP series. |
 | RC offset correction | `drivers/gpu/drm/amd/display/dc/dml/dsc/rc_calc_fpu.c` | local-risk carry | Changes the 8 BPP 4:4:4 RC offset path. This needs headset/display-link evidence before upstream treatment. |
 
+## Compatibility Notes
+
+Observed on 2026-05-09:
+
+- `6.12.y` does not carry the DisplayID formula timing parser blocks that newer
+  stable branches carry, so this patch intentionally does not include the
+  formula-timing `DISPLAYID_BLOCK_DESCRIPTOR_PAYLOAD_BYTES` cleanup from the
+  upstream-overlap series.
+- The Type VII `dsc_passthrough_timings_support` flag is set in
+  `add_displayid_detailed_1_modes()` instead of changing
+  `drm_mode_displayid_detailed()`'s signature. That keeps the carry compatible
+  with `6.12.y`, where the helper still takes non-const timing descriptors,
+  while preserving the same behavior on newer stable branches.
+- The bounded carry dry-run passed for `6.12.87`, `6.18.28`, `6.19.14`, and
+  `7.0.5` after this compatibility adjustment.
+
 ## Split Plan
 
 1. Split parser and DRM propagation into `0007a-vesa-displayid-dsc-bpp-parser.patch`.

--- a/xr/patches/0007-vesa-dsc-bpp.patch
+++ b/xr/patches/0007-vesa-dsc-bpp.patch
@@ -110,16 +110,7 @@ index 5b1b32f73516..8f1a2f33ca1a 100644
  struct displayid_detailed_timing_block {
  	struct displayid_block base;
  	struct displayid_detailed_timings_1 timings[];
-@@ -137,19 +139,28 @@ struct displayid_formula_timings_9 {
- 	u8 vrefresh;
- } __packed;
- 
-+#define DISPLAYID_BLOCK_DESCRIPTOR_PAYLOAD_BYTES	GENMASK(6, 4)
- struct displayid_formula_timing_block {
- 	struct displayid_block base;
- 	struct displayid_formula_timings_9 timings[];
- } __packed;
- 
+@@ -145,9 +147,17 @@
 +#define DISPLAYID_VESA_DP_TYPE		GENMASK(2, 0)
  #define DISPLAYID_VESA_MSO_OVERLAP	GENMASK(3, 0)
  #define DISPLAYID_VESA_MSO_MODE		GENMASK(6, 5)
@@ -294,61 +285,22 @@ index 056eff8cbd1a..26d53a548a27 100644
  
  out:
  	if (drm_edid_has_internal_quirk(connector, EDID_QUIRK_NON_DESKTOP)) {
-@@ -6825,8 +6850,8 @@ static void update_display_info(struct drm_connector *connector,
- }
- 
- static struct drm_display_mode *drm_mode_displayid_detailed(struct drm_device *dev,
--							    const struct displayid_detailed_timings_1 *timings,
--							    bool type_7)
-+							    const struct displayid_block *block,
-+							    const struct displayid_detailed_timings_1 *timings)
- {
- 	struct drm_display_mode *mode;
- 	unsigned int pixel_clock = (timings->pixel_clock[0] |
-@@ -6842,11 +6867,16 @@ static struct drm_mode_displayid_detailed(struct drm_device *dev,
- 	unsigned int vsync_width = le16_to_cpu(timings->vsw) + 1;
- 	bool hsync_positive = le16_to_cpu(timings->hsync) & (1 << 15);
- 	bool vsync_positive = le16_to_cpu(timings->vsync) & (1 << 15);
-+	bool type_7 = block->tag == DATA_BLOCK_2_TYPE_7_DETAILED_TIMING;
- 
- 	mode = drm_mode_create(dev);
- 	if (!mode)
- 		return NULL;
- 
-+	if (type_7 && FIELD_GET(DISPLAYID_BLOCK_REV, block->rev) >= 1)
-+		mode->dsc_passthrough_timings_support =
-+			block->rev & DISPLAYID_BLOCK_PASSTHROUGH_TIMINGS_SUPPORT;
-+
- 	/* resolution is kHz for type VII, and 10 kHz for type I */
- 	mode->clock = type_7 ? pixel_clock : pixel_clock * 10;
- 	mode->hdisplay = hactive;
-@@ -6879,7 +6909,6 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
- 	int num_timings;
- 	struct drm_display_mode *newmode;
- 	int num_modes = 0;
--	bool type_7 = block->tag == DATA_BLOCK_2_TYPE_7_DETAILED_TIMING;
- 	/* blocks must be multiple of 20 bytes length */
- 	if (block->num_bytes % 20)
- 		return 0;
-@@ -6888,7 +6917,7 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
+@@ -6848,10 +6872,14 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
  	for (i = 0; i < num_timings; i++) {
  		struct displayid_detailed_timings_1 *timings = &det->timings[i];
  
 -		newmode = drm_mode_displayid_detailed(connector->dev, timings, type_7);
-+		newmode = drm_mode_displayid_detailed(connector->dev, block, timings);
++		newmode = drm_mode_displayid_detailed(connector->dev, timings, type_7);
  		if (!newmode)
  			continue;
  
-@@ -6935,7 +6964,8 @@ static int add_displayid_formula_modes(struct drm_connector *connector,
- 	struct drm_display_mode *newmode;
- 	int num_modes = 0;
- 	bool type_10 = block->tag == DATA_BLOCK_2_TYPE_10_FORMULA_TIMING;
--	int timing_size = 6 + ((formula_block->base.rev & 0x70) >> 4);
-+	int timing_size = 6 +
-+		FIELD_GET(DISPLAYID_BLOCK_DESCRIPTOR_PAYLOAD_BYTES, formula_block->base.rev);
- 
- 	/* extended blocks are not supported yet */
- 	if (timing_size != 6)
++		if (type_7 && FIELD_GET(DISPLAYID_BLOCK_REV, block->rev) >= 1)
++			newmode->dsc_passthrough_timings_support =
++				block->rev & DISPLAYID_BLOCK_PASSTHROUGH_TIMINGS_SUPPORT;
++
+ 		drm_mode_probed_add(connector, newmode);
+ 		num_modes++;
+ 	}
 diff --git a/include/drm/drm_connector.h b/include/drm/drm_connector.h
 index fa4abfe8971e..a0f86e48192e 100644
 --- a/include/drm/drm_connector.h

--- a/xr/patches/bigscreen-beyond-edid.patch
+++ b/xr/patches/bigscreen-beyond-edid.patch
@@ -12,21 +12,29 @@ EDID manufacturer code: "BIG" (PnP ID 0x0927)
 Ref: https://www.phoronix.com/news/Linux-Bigscreen-Beyond-VR
 Link: https://lore.kernel.org/dri-devel/20240517105555.654262-1-contact@scrumplex.net/
 ---
- drivers/gpu/drm/drm_edid.c | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ drivers/gpu/drm/drm_edid.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
 --- a/drivers/gpu/drm/drm_edid.c
 +++ b/drivers/gpu/drm/drm_edid.c
-@@ -220,6 +220,10 @@ static const struct edid_quirk {
- 	EDID_QUIRK('V', 'L', 'V', 0x91be, BIT(EDID_QUIRK_NON_DESKTOP)),
- 	EDID_QUIRK('V', 'L', 'V', 0x91bf, BIT(EDID_QUIRK_NON_DESKTOP)),
--
+@@ -125,6 +125,12 @@ struct drm_edid_match_closure {
+ 	.quirks = _quirks \
+ }
+ 
++#ifdef EDID_QUIRK_NON_DESKTOP
++#define EDID_QUIRK_NON_DESKTOP_MASK EDID_QUIRK_NON_DESKTOP
++#else
++#define EDID_QUIRK_NON_DESKTOP_MASK BIT(EDID_QUIRK_NON_DESKTOP)
++#endif
 +
+ static const struct edid_quirk {
+ 	const struct drm_edid_ident ident;
+ 	u32 quirks;
+@@ -222,2 +230,6 @@ static const struct edid_quirk {
+ 
 +	/* Bigscreen Beyond VR Headsets */
-+	EDID_QUIRK('B', 'I', 'G', 0x1234, BIT(EDID_QUIRK_NON_DESKTOP)),
-+	EDID_QUIRK('B', 'I', 'G', 0x5095, BIT(EDID_QUIRK_NON_DESKTOP)),
++	EDID_QUIRK('B', 'I', 'G', 0x1234, EDID_QUIRK_NON_DESKTOP_MASK),
++	EDID_QUIRK('B', 'I', 'G', 0x5095, EDID_QUIRK_NON_DESKTOP_MASK),
 +
  	/* HTC Vive and Vive Pro VR Headsets */
- 	EDID_QUIRK('H', 'V', 'R', 0xaa01, BIT(EDID_QUIRK_NON_DESKTOP)),
- 	EDID_QUIRK('H', 'V', 'R', 0xaa02, BIT(EDID_QUIRK_NON_DESKTOP)),

--- a/xr/patches/bigscreen-beyond-edid.route.md
+++ b/xr/patches/bigscreen-beyond-edid.route.md
@@ -33,6 +33,9 @@ As of 2026-04-25:
   this manufacturer/product ID is not marked with `EDID_QUIRK_NON_DESKTOP`.
 - The carry patch has been cleaned so `git apply --check` succeeds against
   current `xr/main`.
+- The release carry uses `EDID_QUIRK_NON_DESKTOP_MASK` so the same patch works
+  across the older `6.12.y` bitmask-style EDID quirk definitions and newer
+  enum-plus-`BIT()` sources.
 - The stale `mail-archive.com` reference has been replaced with a
   `lore.kernel.org` link to the prior public posting.
 


### PR DESCRIPTION
## Summary

- make the VESA DisplayID DSC carry apply cleanly to the `6.12.y` source shape
- avoid the helper-signature drift by setting Type VII DSC passthrough state in the caller
- document the `6.12.87` fallback status and patch compatibility notes
- teach `git diff --check` not to flag valid unified-diff context indentation in `*.patch` files

## Validation

- `patch --batch -d "$TMPDIR/linux-xr-carry-6.12.87/linux-6.12.87" -p1 --dry-run < xr/patches/0007-vesa-dsc-bpp.patch`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.12.87`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.18.28`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5`
- `bash xr/scripts/triage-upstream-targets.sh --run-preflight --output /tmp/linux-xr-upstream-target-triage-2026-05-09-after-dsc.md`
- `bash xr/scripts/build-rpm.sh --kernel-version 6.12.87 --xr-release 1 --security-preflight-only`
- `bash -n xr/scripts/build-rpm.sh xr/scripts/check-kernel-carry.sh xr/scripts/generate-cadence-report.sh xr/scripts/triage-upstream-targets.sh`
- `git diff --check`
- `nix flake check --system x86_64-linux`

Closes #57.
