### PR TITLE
[codex] security: track Dirty Frag CVE floors

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -269,8 +269,8 @@ jobs:
             - `0007-vesa-dsc-bpp.patch` — VESA DisplayID DSC BPP parser + QP/RC fixes
             - `bigscreen-beyond-edid.patch` — EDID non-desktop quirk (BIG/0x1234 + 0x5095)
             - `cve-2026-31431-algif-aead.patch` — applied automatically for vulnerable 6.19.x bases
-            - `dirtyfrag-esp-shared-frag.patch` — applied automatically for Dirty Frag ESP-affected bases
-            - `dirtyfrag-rxrpc-linearize.patch` — applied automatically for Dirty Frag RxRPC-affected bases
+            - `dirtyfrag-esp-shared-frag.patch` — applied automatically for CVE-2026-43284 Dirty Frag ESP-affected bases
+            - `dirtyfrag-rxrpc-linearize.patch` — applied automatically for reserved CVE-2026-43500 Dirty Frag RxRPC-affected bases
             - PREEMPT_RT (RT variant only)
 
             ### Install

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The real RPM release lane remains [`build-kernel.yml`](.github/workflows/build-k
 | `0007-vesa-dsc-bpp.patch` | VESA DisplayID DSC BPP parser, QP table + RC offset fixes for 8bpc 4:4:4 @ 8 BPP |
 | `bigscreen-beyond-edid.patch` | EDID non-desktop quirk for Beyond (BIG/0x1234 + 0x5095) |
 | `cve-2026-31431-algif-aead.patch` | CVE-2026-31431 stable `6.19.y` security backport, applied automatically for vulnerable 6.19.x bases |
-| `dirtyfrag-esp-shared-frag.patch` | Dirty Frag ESP page-cache write hardening, applied automatically for supported vulnerable bases |
-| `dirtyfrag-rxrpc-linearize.patch` | Dirty Frag RxRPC RXKAD in-place decrypt hardening, applied automatically for supported vulnerable bases |
+| `dirtyfrag-esp-shared-frag.patch` | CVE-2026-43284 Dirty Frag ESP page-cache write hardening, applied automatically for supported vulnerable bases |
+| `dirtyfrag-rxrpc-linearize.patch` | Reserved CVE-2026-43500 Dirty Frag RxRPC RXKAD in-place decrypt hardening, applied automatically for supported vulnerable bases |
 | `patch-6.19.3-rt1.patch` | PREEMPT_RT real-time scheduling (RT variant only, downloaded from kernel.org) |
 
 XR carry patches are maintained in this repository under [`xr/patches`](xr/patches).
@@ -275,8 +275,9 @@ backport in
 Other vulnerable or unknown bases are refused unless
 `LINUX_XR_ALLOW_CVE_2026_31431=1` is set for explicit validation.
 
-The Dirty Frag gate tracks the ESP shared-frag fix and the separate RxRPC
-RXKAD in-place decrypt sink. Supported vulnerable bases apply
+The Dirty Frag gate tracks `CVE-2026-43284` for the ESP shared-frag fix and
+the separate reserved `CVE-2026-43500` RxRPC RXKAD in-place decrypt sink.
+Supported vulnerable bases apply
 [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch)
 and/or
 [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch)
@@ -310,7 +311,8 @@ adding, dropping, or upstreaming a repo-managed CVE or public security backport.
 | CVE | Public name | linux-xr status | Repo links | External references |
 | --- | --- | --- | --- | --- |
 | CVE-2026-31431 | Copy Fail / `algif_aead` AF_ALG local privilege escalation | Patched in `v6.19.5-xr9` and carried forward in `v6.19.5-xr10` by applying the stable `6.19.y` backport on top of the vulnerable `6.19.5` base; fixed natively by upstream affected-range floors such as `6.19.12+`, `6.18.22+`, `6.12.85+`, `6.6.137+`, `6.1.170+`, `5.15.204+`, `5.10.254+`, and `7.0+` bases | [`xr/security/cve-2026-31431-algif-aead.patch`](xr/security/cve-2026-31431-algif-aead.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`xr/scripts/check-cve-2026-31431-live.sh`](xr/scripts/check-cve-2026-31431-live.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-31431), [Red Hat RHSB-2026-02](https://access.redhat.com/security/vulnerabilities/RHSB-2026-02), [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-31431), [Copy Fail](https://copy.fail/) |
-| Pending / none assigned | Dirty Frag / ESP and RxRPC page-cache writes | `v6.19.5-xr10` carries repo-managed ESP and RxRPC backports on the vulnerable `6.19.5` base. Supported vulnerable `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` RPM bases apply the relevant repo backports. `7.0.5` has the ESP fix natively, but still needs the linux-xr RxRPC carry; `6.12.87` has ESP fixed natively, a linux-xr RxRPC build route, and a DSC carry dry-run route, but still needs an RPM proof before fallback promotion. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
+| CVE-2026-43284 | Dirty Frag / ESP page-cache write | `v6.19.5-xr10` carries the repo-managed ESP backport on the vulnerable `6.19.5` base. Published fixed floors include `5.10.255+`, `5.15.205+`, `6.1.171+`, `6.6.138+`, `6.12.87+`, `6.18.28+`, and `7.0.5+`; EOL `6.19.x` stays conservative and uses the repo backport. | [`xr/security/dirtyfrag-esp-shared-frag.patch`](xr/security/dirtyfrag-esp-shared-frag.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-43284), [CVE record](https://www.cve.org/CVERecord?id=CVE-2026-43284), [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [ESP netdev fix f4c50a4034e6](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e6) |
+| CVE-2026-43500 (reserved) | Dirty Frag / RxRPC page-cache write | `v6.19.5-xr10` carries the repo-managed RxRPC RXKAD linearize/COW hardening on the vulnerable `6.19.5` base. As of the 2026-05-09 linux-xr check, the CVE is reserved but not public in NVD/CVE.org and no upstream fixed floor is recorded in the gate, so supported `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` bases rely on the linux-xr backport. | [`xr/security/dirtyfrag-rxrpc-linearize.patch`](xr/security/dirtyfrag-rxrpc-linearize.patch), [`xr/scripts/build-rpm.sh`](xr/scripts/build-rpm.sh), [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10) | [Dirty Frag](https://github.com/Jesssullivan/dirtyfrag), [RxRPC patch route](https://lore.kernel.org/all/afKV2zGR6rrelPC7@v4bel/) |
 
 ## SELinux and Security Config
 
@@ -341,8 +343,9 @@ drift fails before an RPM can be accepted.
 As of 2026-05-09, the latest published secured linux-xr lab release is
 [`v6.19.5-xr10`](https://github.com/tinyland-inc/linux-xr/releases/tag/v6.19.5-xr10).
 It keeps the `6.19.5` lab base but carries repo-managed
-[`CVE-2026-31431`](#known-patched-cves-and-security-backports), Dirty Frag ESP,
-and Dirty Frag RxRPC backports. The generic `xr10` runtime is boot-proven on
+[`CVE-2026-31431`](#known-patched-cves-and-security-backports),
+`CVE-2026-43284` Dirty Frag ESP, and reserved-`CVE-2026-43500` Dirty Frag
+RxRPC backports. The generic `xr10` runtime is boot-proven on
 `mbp-13` and `honey`; RT artifacts are published but remain gated on explicit
 RT host validation. Kernel.org now lists
 `6.19.14` as EOL; it remains useful as a bounded compatibility proof, but it
@@ -358,12 +361,13 @@ Current ingestion checkpoint:
   the `linux-6.19.14` tarball, and the security preflight passes by applying
   the repo-managed Dirty Frag backports.
 - Generic `6.18.28` longterm and `7.0.5` stable are maintained-base candidates:
-  the XR carry patches dry-run cleanly against both tarballs, and the security
-  preflight passes by applying the required repo-managed Dirty Frag backports.
-- Generic `6.12.87` now passes bounded carry and security preflight: the
-  tarball has the ESP shared-frag hardening, the repo-managed Dirty Frag RxRPC
-  route applies, and the DSC carry has a 6.12-compatible dry-run path. Keep it
-  as a fallback candidate until a real RPM proof succeeds.
+  the XR carry patches dry-run cleanly against both tarballs. Both have
+  `CVE-2026-43284` ESP fixed natively and still use the repo-managed
+  reserved-`CVE-2026-43500` RxRPC route until an upstream fixed floor is proven.
+- Generic `6.12.87` has `CVE-2026-43284` ESP fixed natively and now has a
+  repo-managed reserved-`CVE-2026-43500` RxRPC route. It remains a fallback
+  candidate, but its real RPM proof is blocked on a zero-fuzz DSC carry conflict
+  found in `%prep`.
 - RT `7.0.1-rt2` and `6.19.3-rt1` pass the bounded carry/security preflights;
   RT `6.18.13-rt4` still fails the CVE-2026-31431 gate. Keep RT promotion
   separate from the generic SOTA target until a same-base RT patchset or local
@@ -382,7 +386,8 @@ Current ingestion checkpoint:
 | Patch/workstream | Upstream status | Next action |
 |-------|----------------|-----|
 | CVE-2026-31431 / Copy Fail / `algif_aead` | Fixed upstream in `7.0` and stable affected-range floors including `6.19.12`, `6.18.22`, `6.12.85`, `6.6.137`, `6.1.170`, `5.15.204`, and `5.10.254`; `v6.19.5-xr10` carries the `6.19.y` backport on the current `6.19.5` lab base | Keep fleet rollout on `xr10`, then rebase the generic lane to a maintained target such as `7.0.5` stable or `6.18.28` longterm under issue #37. Treat stock 6.12-class hosts as exposed to Dirty Frag RxRPC unless a vendor backport, mitigation, or linux-xr route is proven and installed. |
-| Dirty Frag / ESP + RxRPC page-cache writes | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and appears in `7.0.5`; the `6.12.87` tarball also has ESP hardening; RxRPC still needs explicit tracking because no `skb_linearize_cow()` RxRPC hardening was observed in Linus `master` or checked stable branch heads | Keep `v6.19.5-xr10` as the current secured lab release, keep carrying RxRPC on source-sync candidates until upstream/vendor fixed floors are proven, and treat `6.12.87` as a fallback candidate only after an RPM proof succeeds. |
+| CVE-2026-43284 / Dirty Frag ESP page-cache write | ESP shared-frag fix is in netdev/net commit `f4c50a4034e6` and published in stable floors including `6.12.87`, `6.18.28`, and `7.0.5`; the EOL `6.19.5` lab base remains protected by the repo backport | Keep `v6.19.5-xr10` as the current secured lab release, stop treating fixed maintained bases as needing the ESP backport, and keep `6.12.87` as a fallback candidate only after an RPM proof succeeds. |
+| CVE-2026-43500 / Dirty Frag RxRPC page-cache write | CVE is reserved but not yet public in NVD/CVE.org as of 2026-05-09; no upstream fixed floor is recorded in the gate, and no `skb_linearize_cow()` RxRPC hardening was observed in Linus `master` or checked stable branch heads | Keep carrying RxRPC on source-sync candidates until upstream/vendor fixed floors are proven. |
 | VESA DisplayID DSC BPP parser / amdgpu handling | In-flight upstream series; not present in current upstream checkout | Track Bolyukin v7 fixed-DSC-BPP series and drop this part when it lands. |
 | QP table + RC offset adjustments | Local carry; not submitted as a standalone upstream series | Split from the DisplayID parser carry using `xr/patches/0007-vesa-dsc-bpp.map.md` and decide whether this is evidence-backed upstream material or host-only risk. |
 | EDID non-desktop quirk for `BIG/0x1234` and `BIG/0x5095` | Absent from current upstream checkout | Follow `xr/patches/bigscreen-beyond-edid.route.md`: local `BIG/0x1234` evidence now proves `non-desktop=1`; next regenerate an upstream/drm-misc topic patch and send via the DRM route. |

--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -20,6 +20,8 @@ SERIES_FILE="${PATCH_DIR}/series"
 SECURITY_DIR="${XR_DIR}/security"
 SECURITY_CONFIG_CHECK="${XR_DIR}/scripts/check-security-config.sh"
 CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
+DIRTYFRAG_ESP_CVE="CVE-2026-43284"
+DIRTYFRAG_RXRPC_CVE="CVE-2026-43500"
 DIRTYFRAG_ESP_PATCH="dirtyfrag-esp-shared-frag.patch"
 DIRTYFRAG_RXRPC_PATCH="dirtyfrag-rxrpc-linearize.patch"
 APPLY_CVE_2026_31431_PATCH=0
@@ -244,16 +246,90 @@ dirtyfrag_esp_status() {
         return
     fi
 
-    if (( major == 6 && minor == 12 )); then
-        if (( patch >= 87 )); then
-            echo "fixed"
-        else
-            echo "vulnerable"
-        fi
+    if (( major == 6 && minor == 19 )); then
+        echo "vulnerable"
         return
     fi
 
-    if (( major == 6 && (minor == 18 || minor == 19) )); then
+    if (( major == 6 )); then
+        case "${minor}" in
+            18)
+                if (( patch >= 28 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            13|14|15|16|17)
+                echo "vulnerable"
+                ;;
+            12)
+                if (( patch >= 87 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            7|8|9|10|11)
+                echo "vulnerable"
+                ;;
+            6)
+                if (( patch >= 138 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            2|3|4|5)
+                echo "vulnerable"
+                ;;
+            1)
+                if (( patch >= 171 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            0)
+                echo "vulnerable"
+                ;;
+            *)
+                echo "unknown"
+                ;;
+        esac
+        return
+    fi
+
+    if (( major == 5 )); then
+        case "${minor}" in
+            16|17|18|19)
+                echo "vulnerable"
+                ;;
+            15)
+                if (( patch >= 205 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            12|13|14)
+                echo "vulnerable"
+                ;;
+            10)
+                if (( patch >= 255 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            *)
+                echo "unknown"
+                ;;
+        esac
+        return
+    fi
+
+    if (( major == 4 && minor >= 11 )); then
         echo "vulnerable"
         return
     fi
@@ -271,7 +347,8 @@ dirtyfrag_esp_repo_backport_applies() {
         return 1
     fi
 
-    (( major == 6 && (minor == 18 || minor == 19) )) ||
+    (( major == 6 && minor == 18 && patch < 28 )) ||
+        (( major == 6 && minor == 19 )) ||
         (( major == 7 && minor == 0 && patch < 5 ))
 }
 
@@ -368,20 +445,20 @@ enforce_dirtyfrag_gate() {
             if dirtyfrag_esp_repo_backport_applies "${KERNEL_VERSION}" \
                 && [[ -f "${SECURITY_DIR}/${DIRTYFRAG_ESP_PATCH}" ]]; then
                 APPLY_DIRTYFRAG_ESP_PATCH=1
-                echo ">>> Dirty Frag ESP: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_ESP_PATCH}."
+                echo ">>> ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_ESP_PATCH}."
             elif [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
-                echo "WARNING: building ${KERNEL_VERSION} despite Dirty Frag ESP vulnerable range."
+                echo "WARNING: building ${KERNEL_VERSION} despite ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP vulnerable range."
             else
-                echo "ERROR: refusing to build ${KERNEL_VERSION}; Dirty Frag ESP status is vulnerable and no repo-managed backport route is enabled." >&2
+                echo "ERROR: refusing to build ${KERNEL_VERSION}; ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP status is vulnerable and no repo-managed backport route is enabled." >&2
                 echo "ERROR: use a fixed upstream floor, port ${DIRTYFRAG_ESP_PATCH}, or set LINUX_XR_ALLOW_DIRTYFRAG=1 only for explicit validation." >&2
                 exit 1
             fi
             ;;
         unknown)
             if [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
-                echo "WARNING: Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}; override accepted."
+                echo "WARNING: ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}; override accepted."
             else
-                echo "ERROR: Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}." >&2
+                echo "ERROR: ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP fixed status is unknown for ${KERNEL_VERSION}." >&2
                 echo "ERROR: update the security gate or set LINUX_XR_ALLOW_DIRTYFRAG=1 for an explicit validation build." >&2
                 exit 1
             fi
@@ -394,20 +471,20 @@ enforce_dirtyfrag_gate() {
             if dirtyfrag_rxrpc_repo_backport_applies "${KERNEL_VERSION}" \
                 && [[ -f "${SECURITY_DIR}/${DIRTYFRAG_RXRPC_PATCH}" ]]; then
                 APPLY_DIRTYFRAG_RXRPC_PATCH=1
-                echo ">>> Dirty Frag RxRPC: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_RXRPC_PATCH}."
+                echo ">>> ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC: ${KERNEL_VERSION} is vulnerable; applying ${DIRTYFRAG_RXRPC_PATCH}."
             elif [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
-                echo "WARNING: building ${KERNEL_VERSION} despite Dirty Frag RxRPC vulnerable range."
+                echo "WARNING: building ${KERNEL_VERSION} despite ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC vulnerable range."
             else
-                echo "ERROR: refusing to build ${KERNEL_VERSION}; Dirty Frag RxRPC status is vulnerable and no repo-managed backport route is enabled." >&2
+                echo "ERROR: refusing to build ${KERNEL_VERSION}; ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC status is vulnerable and no repo-managed backport route is enabled." >&2
                 echo "ERROR: use a fixed upstream floor, port ${DIRTYFRAG_RXRPC_PATCH}, or set LINUX_XR_ALLOW_DIRTYFRAG=1 only for explicit validation." >&2
                 exit 1
             fi
             ;;
         unknown)
             if [[ "${LINUX_XR_ALLOW_DIRTYFRAG:-}" == "1" ]]; then
-                echo "WARNING: Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}; override accepted."
+                echo "WARNING: ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}; override accepted."
             else
-                echo "ERROR: Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}." >&2
+                echo "ERROR: ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC fixed status is unknown for ${KERNEL_VERSION}." >&2
                 echo "ERROR: update the security gate or set LINUX_XR_ALLOW_DIRTYFRAG=1 for an explicit validation build." >&2
                 exit 1
             fi

--- a/xr/scripts/generate-cadence-report.sh
+++ b/xr/scripts/generate-cadence-report.sh
@@ -16,7 +16,9 @@ CVE_2026_31431_6_19_FIX="ce42ee423e58dffa5ec03524054c9d8bfd4f6237"
 CVE_2026_31431_6_18_FIX="fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8"
 CVE_2026_31431_6_12_FIX="8b88d99341f139e23bdeb1027a2a3ae10d341d82"
 CVE_2026_31431_PATCH="cve-2026-31431-algif-aead.patch"
+DIRTYFRAG_ESP_CVE="CVE-2026-43284"
 DIRTYFRAG_ESP_FIX="f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"
+DIRTYFRAG_RXRPC_CVE="CVE-2026-43500"
 DIRTYFRAG_ESP_PATCH="dirtyfrag-esp-shared-frag.patch"
 DIRTYFRAG_RXRPC_PATCH="dirtyfrag-rxrpc-linearize.patch"
 
@@ -434,16 +436,90 @@ dirtyfrag_esp_version_status() {
         return
     fi
 
-    if (( major == 6 && minor == 12 )); then
-        if (( patch >= 87 )); then
-            echo "fixed"
-        else
-            echo "vulnerable"
-        fi
+    if (( major == 6 && minor == 19 )); then
+        echo "vulnerable"
         return
     fi
 
-    if (( major == 6 && (minor == 18 || minor == 19) )); then
+    if (( major == 6 )); then
+        case "${minor}" in
+            18)
+                if (( patch >= 28 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            13|14|15|16|17)
+                echo "vulnerable"
+                ;;
+            12)
+                if (( patch >= 87 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            7|8|9|10|11)
+                echo "vulnerable"
+                ;;
+            6)
+                if (( patch >= 138 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            2|3|4|5)
+                echo "vulnerable"
+                ;;
+            1)
+                if (( patch >= 171 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            0)
+                echo "vulnerable"
+                ;;
+            *)
+                echo "unknown"
+                ;;
+        esac
+        return
+    fi
+
+    if (( major == 5 )); then
+        case "${minor}" in
+            16|17|18|19)
+                echo "vulnerable"
+                ;;
+            15)
+                if (( patch >= 205 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            12|13|14)
+                echo "vulnerable"
+                ;;
+            10)
+                if (( patch >= 255 )); then
+                    echo "fixed"
+                else
+                    echo "vulnerable"
+                fi
+                ;;
+            *)
+                echo "unknown"
+                ;;
+        esac
+        return
+    fi
+
+    if (( major == 4 && minor >= 11 )); then
         echo "vulnerable"
         return
     fi
@@ -461,7 +537,8 @@ dirtyfrag_esp_repo_backport_applies() {
         return 1
     fi
 
-    (( major == 6 && (minor == 18 || minor == 19) )) ||
+    (( major == 6 && minor == 18 && patch < 28 )) ||
+        (( major == 6 && minor == 19 )) ||
         (( major == 7 && minor == 0 && patch < 5 ))
 }
 
@@ -676,13 +753,13 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo "| CVE-2026-31431 repo backport \`${CVE_2026_31431_PATCH}\` | \`$(cve_2026_31431_repo_backport_status)\` |"
     echo "| CVE-2026-31431 default build route | \`$(cve_2026_31431_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
     echo "| CVE-2026-31431 upstream/mainline fix \`${CVE_2026_31431_MAINLINE_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${CVE_2026_31431_MAINLINE_FIX}")\` |"
-    echo "| Dirty Frag ESP default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_esp_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
-    echo "| Dirty Frag ESP repo backport \`${DIRTYFRAG_ESP_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_ESP_PATCH}")\` |"
-    echo "| Dirty Frag ESP default build route | \`$(dirtyfrag_esp_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
-    echo "| Dirty Frag ESP upstream fix \`${DIRTYFRAG_ESP_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${DIRTYFRAG_ESP_FIX}")\` |"
-    echo "| Dirty Frag RxRPC default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_rxrpc_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
-    echo "| Dirty Frag RxRPC repo backport \`${DIRTYFRAG_RXRPC_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_RXRPC_PATCH}")\` |"
-    echo "| Dirty Frag RxRPC default build route | \`$(dirtyfrag_rxrpc_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_esp_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP repo backport \`${DIRTYFRAG_ESP_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_ESP_PATCH}")\` |"
+    echo "| ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP default build route | \`$(dirtyfrag_esp_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| ${DIRTYFRAG_ESP_CVE} Dirty Frag ESP upstream fix \`${DIRTYFRAG_ESP_FIX:0:12}\` in upstream ref | \`$(ref_contains_commit "${UPSTREAM_REF}" "${DIRTYFRAG_ESP_FIX}")\` |"
+    echo "| ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC default base kernel \`${DEFAULT_KERNEL_VERSION:-unavailable}\` | \`$(dirtyfrag_rxrpc_version_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
+    echo "| ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC repo backport \`${DIRTYFRAG_RXRPC_PATCH}\` | \`$(security_patch_status "${DIRTYFRAG_RXRPC_PATCH}")\` |"
+    echo "| ${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC default build route | \`$(dirtyfrag_rxrpc_build_route_status "${DEFAULT_KERNEL_VERSION:-unknown}")\` |"
     if [[ "${#STABLE_REFS[@]}" -gt 0 ]]; then
         for stable_ref in "${STABLE_REFS[@]}"; do
             echo "| CVE-2026-31431 fix in candidate ref \`${stable_ref}\` | \`$(cve_2026_31431_ref_fix_status "${stable_ref}")\` |"
@@ -693,7 +770,8 @@ trap 'rm -f "${tmp_report}"' EXIT
     echo
     echo "Known fixed floors for this gate include: \`5.10.254+\`, \`5.15.204+\`, \`6.1.170+\`, \`6.6.137+\`, \`6.12.85+\`, \`6.18.22+\`, \`6.19.12+\`, and \`7.0+\`."
     echo "For vulnerable \`6.19.x\` bases, \`build-rpm.sh\` applies the repo backport when present."
-    echo "Dirty Frag ESP is tracked as fixed in \`7.0.5+\` for the \`7.0.x\` lane; Dirty Frag RxRPC has no upstream fixed floor recorded here yet, so supported bases rely on the repo backport."
+    echo "${DIRTYFRAG_ESP_CVE} Dirty Frag ESP fixed floors include \`5.10.255+\`, \`5.15.205+\`, \`6.1.171+\`, \`6.6.138+\`, \`6.12.87+\`, \`6.18.28+\`, and \`7.0.5+\`; the EOL \`6.19.x\` lab line stays conservative and uses the repo backport."
+    echo "${DIRTYFRAG_RXRPC_CVE} Dirty Frag RxRPC is reserved but not public in NVD/CVE.org in the last linux-xr check; no upstream fixed floor is recorded here yet, so supported bases rely on the repo backport."
     echo
     echo "## Carry Apply Triage"
     echo

--- a/xr/security/README.md
+++ b/xr/security/README.md
@@ -10,8 +10,8 @@ feature carry; use `xr/patches/` for that path.
 | Patch | Source | Build behavior |
 | --- | --- | --- |
 | `cve-2026-31431-algif-aead.patch` | Linux stable `6.19.y` commit `ce42ee423e58`, backporting mainline `a664bf3d603d` | Applied automatically for vulnerable `6.19.x` bases before RT and XR carry patches |
-| `dirtyfrag-esp-shared-frag.patch` | Dirty Frag ESP mitigation from netdev/net commit `f4c50a4034e6` | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and pre-`7.0.5` `7.0.x` bases before RT and XR carry patches |
-| `dirtyfrag-rxrpc-linearize.patch` | linux-xr RXKAD backport adapted from the public Dirty Frag RxRPC patch route | Applied automatically for supported vulnerable `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` bases before RT and XR carry patches |
+| `dirtyfrag-esp-shared-frag.patch` | `CVE-2026-43284` Dirty Frag ESP mitigation from netdev/net commit `f4c50a4034e6` | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and pre-`7.0.5` `7.0.x` bases before RT and XR carry patches; fixed maintained bases such as `6.12.87`, `6.18.28`, and `7.0.5` do not need this backport |
+| `dirtyfrag-rxrpc-linearize.patch` | Reserved `CVE-2026-43500` linux-xr RXKAD backport adapted from the public Dirty Frag RxRPC patch route | Applied automatically for supported vulnerable `6.12.x`, `6.18.x`, `6.19.x`, and `7.0.x` bases before RT and XR carry patches until an upstream fixed floor is published and proven |
 
 Other affected kernel lines remain guarded by `xr/scripts/build-rpm.sh`, but do
 not have repo-managed backports here. Use a fixed upstream floor, vendor-fixed

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -12,8 +12,9 @@ As of 2026-05-09:
 - Bounded EOL compatibility proof target: `v6.19.14`
 - Maintained generic candidate targets: `v7.0.5` stable and `v6.18.28` longterm
 - Longterm fallback watch: `v6.12.87`, currently blocked for linux-xr because
-  the DSC carry conflicts and Dirty Frag RxRPC has no repo-managed `6.12`
-  backport route
+  the RPM proof hit a zero-fuzz DSC carry conflict. `6.12.87` has
+  `CVE-2026-43284` ESP fixed natively and now has a repo-managed
+  reserved-`CVE-2026-43500` RxRPC build route.
 - RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
 - RT blockers: newest stable `v7.0.5` has no matching RT patch yet; `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13 backport
 
@@ -57,10 +58,11 @@ Required checks before moving build defaults or release tags:
 ./xr/scripts/build-rpm.sh --kernel-version 7.0.5 --xr-release 1 --security-preflight-only
 ```
 
-The `6.12.87` tarball contains the ESP shared-frag hardening, but the
-`rxkad.c` tree does not contain the Dirty Frag RxRPC linearize/COW hardening.
-Do not use `6.12.87` as a linux-xr fallback unless the DSC carry is refreshed
-and the RxRPC security route is resolved.
+The `6.12.87` tarball contains the `CVE-2026-43284` ESP shared-frag hardening,
+but the `rxkad.c` tree does not contain the reserved-`CVE-2026-43500` Dirty
+Frag RxRPC linearize/COW hardening. Do not promote `6.12.87` as a linux-xr
+fallback until the zero-fuzz DSC carry conflict is fixed and an RPM proof
+succeeds with the RxRPC security route applied.
 
 RT remains separate until a compatible RT patch is proven:
 

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -85,10 +85,10 @@ on AMD GPUs (RDNA2+). Includes:
 - CVE-2026-31431 algif_aead backport
 %endif
 %if 0%{?apply_dirtyfrag_esp_patch}
-- Dirty Frag ESP shared-frag hardening
+- CVE-2026-43284 Dirty Frag ESP shared-frag hardening
 %endif
 %if 0%{?apply_dirtyfrag_rxrpc_patch}
-- Dirty Frag RxRPC RXKAD in-place decrypt hardening
+- CVE-2026-43500 Dirty Frag RxRPC RXKAD in-place decrypt hardening
 %endif
 %if "%{rt_version}" != ""
 - PREEMPT_RT real-time scheduling (%{rt_version})


### PR DESCRIPTION
## Summary

- Record CVE-2026-43284 for the Dirty Frag ESP page-cache write issue and reserved CVE-2026-43500 for the RxRPC page-cache write track.
- Update the ESP security gate to use the published fixed floors from NVD/CVE while keeping the EOL 6.19.x lab line conservative.
- Keep RxRPC gated as vulnerable on supported bases until an upstream fixed floor is published and proven.

## Validation

- `bash -n xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh xr/scripts/check-kernel-carry.sh`
- `./xr/scripts/build-rpm.sh --kernel-version 6.19.5 --xr-release 10 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.18.28 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.12.87 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 7.0.5 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.18.27 --xr-release 1 --security-preflight-only`
- `./xr/scripts/build-rpm.sh --kernel-version 6.6.137 --xr-release 1 --security-preflight-only` refused as expected
- `./xr/scripts/build-rpm.sh --kernel-version 6.6.138 --xr-release 1 --security-preflight-only` refused as expected due unknown RxRPC status
- `bash xr/scripts/generate-cadence-report.sh --skip-patch-triage --output -`
- `git diff --check`
- `nix flake check --system x86_64-linux`

## Notes

CVE-2026-43500 is tracked here as reserved because NVD returned no record and CVE.org returned 404 from this check on 2026-05-09. The linux-xr RxRPC backport remains the enforced route for supported bases.
