### PR TITLE
[codex] carry: enforce zero-fuzz patch checks

### DIFF
--- a/xr/patches/0007-vesa-dsc-bpp.map.md
+++ b/xr/patches/0007-vesa-dsc-bpp.map.md
@@ -40,8 +40,9 @@ Observed on 2026-05-09:
   `drm_mode_displayid_detailed()`'s signature. That keeps the carry compatible
   with `6.12.y`, where the helper still takes non-const timing descriptors,
   while preserving the same behavior on newer stable branches.
-- The bounded carry dry-run passed for `6.12.87`, `6.18.28`, `6.19.14`, and
-  `7.0.5` after this compatibility adjustment.
+- The bounded carry dry-run must pass with RPM-compatible zero-fuzz matching
+  for `6.12.87`, `6.18.28`, `6.19.14`, and `7.0.5` before this carry can gate
+  a source-sync or fallback release.
 
 ## Split Plan
 

--- a/xr/patches/0007-vesa-dsc-bpp.patch
+++ b/xr/patches/0007-vesa-dsc-bpp.patch
@@ -102,14 +102,10 @@ index 5b1b32f73516..8f1a2f33ca1a 100644
  struct displayid_block {
  	u8 tag;
  	u8 rev;
-@@ -125,6 +126,7 @@ struct displayid_detailed_timings_1 {
- 	__le16 vsw;
- } __packed;
+@@ -127,2 +128,3 @@
  
 +#define DISPLAYID_BLOCK_PASSTHROUGH_TIMINGS_SUPPORT	BIT(3)
  struct displayid_detailed_timing_block {
- 	struct displayid_block base;
- 	struct displayid_detailed_timings_1 timings[];
 @@ -145,9 +147,17 @@
 +#define DISPLAYID_VESA_DP_TYPE		GENMASK(2, 0)
  #define DISPLAYID_VESA_MSO_OVERLAP	GENMASK(3, 0)
@@ -276,15 +272,11 @@ index 056eff8cbd1a..26d53a548a27 100644
  
  	kfree(info->vics);
  	info->vics = NULL;
-@@ -6795,7 +6820,7 @@ static void update_display_info(struct drm_connector *connector,
- 	if (edid->features & DRM_EDID_FEATURE_RGB_YCRCB422)
- 		info->color_formats |= DRM_COLOR_FORMAT_YCBCR422;
+@@ -6798,3 +6823,3 @@ static void update_display_info(struct drm_connector *connector,
  
 -	drm_update_mso(connector, drm_edid);
 +	drm_update_vesa_specific_block(connector, drm_edid);
  
- out:
- 	if (drm_edid_has_internal_quirk(connector, EDID_QUIRK_NON_DESKTOP)) {
 @@ -6848,10 +6872,14 @@ static int add_displayid_detailed_1_modes(struct drm_connector *connector,
  	for (i = 0; i < num_timings; i++) {
  		struct displayid_detailed_timings_1 *timings = &det->timings[i];

--- a/xr/scripts/check-kernel-carry.sh
+++ b/xr/scripts/check-kernel-carry.sh
@@ -18,7 +18,8 @@ usage() {
 Usage: check-kernel-carry.sh --kernel-version VER [--rt-version RT_VER] [--work-dir DIR] [--keep-work]
 
 Downloads a kernel.org tarball, optionally dry-runs the matching PREEMPT_RT
-patch first, then dry-runs every patch listed in xr/patches/series.
+patch first, then dry-runs every patch listed in xr/patches/series with
+RPM-compatible zero-fuzz matching.
 
 Examples:
   ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
@@ -136,7 +137,7 @@ while IFS= read -r patch_file; do
     fi
 
     echo "    ${patch_file}"
-    patch --batch -d "${SOURCE_DIR}" -p1 --dry-run < "${PATCH_DIR}/${patch_file}"
+    patch --batch -d "${SOURCE_DIR}" -p1 --fuzz=0 --dry-run < "${PATCH_DIR}/${patch_file}"
 done < "${SERIES_FILE}"
 
 echo "=== linux-xr carry dry-run passed for ${KERNEL_VERSION}${RT_VERSION:+ with ${RT_VERSION}} ==="


### PR DESCRIPTION
## Summary

- Narrow two DSC carry hunks so RPM `%patch` zero-fuzz mode applies cleanly to `6.12.87` while preserving newer stable targets.
- Make `check-kernel-carry.sh` dry-run linux-xr carry patches with `--fuzz=0`, matching RPM `%prep` closely enough to catch this class of failure before CI proof builds.
- Update the DSC carry note to require zero-fuzz validation across the maintained candidate matrix.

## Validation

- RPM-style local prep reproduction for `6.12.87`: RxRPC security patch with `--fuzz=0`, DSC carry with `--fuzz=0`, then EDID patch with its intentional `--fuzz=3` allowance.
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.12.87`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.18.28`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14`
- `bash xr/scripts/check-kernel-carry.sh --kernel-version 7.0.5`
- `bash -n xr/scripts/check-kernel-carry.sh xr/scripts/build-rpm.sh xr/scripts/generate-cadence-report.sh`
- `bash xr/scripts/build-rpm.sh --kernel-version 6.12.87 --xr-release 1 --security-preflight-only`
- `git diff --check origin/xr/main..HEAD`
- `nix flake check --system x86_64-linux`

## Notes

This addresses the `%prep` failure from the `6.12.87` generic RPM proof run. The failed proof was caused by exact-context patch application, not by the Dirty Frag security gate.
