### PR TITLE
[codex] config: keep firmware helper disabled on 6.12

### DIFF
--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -11,10 +11,12 @@ As of 2026-05-09:
   `mbp-13` and `honey`
 - Bounded EOL compatibility proof target: `v6.19.14`
 - Maintained generic candidate targets: `v7.0.5` stable and `v6.18.28` longterm
-- Longterm fallback watch: `v6.12.87`, currently blocked for linux-xr because
-  the RPM proof hit a zero-fuzz DSC carry conflict. `6.12.87` has
-  `CVE-2026-43284` ESP fixed natively and now has a repo-managed
-  reserved-`CVE-2026-43500` RxRPC build route.
+- Longterm fallback watch: `v6.12.87`, still pending a successful RPM proof.
+  `6.12.87` has `CVE-2026-43284` ESP fixed natively and now has a
+  repo-managed reserved-`CVE-2026-43500` RxRPC build route. The zero-fuzz DSC
+  carry conflict is fixed; the next proof gate is preserving the
+  `CONFIG_FW_LOADER_USER_HELPER=n` systemd/Rocky boot contract on this older
+  Kconfig.
 - RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
 - RT blockers: newest stable `v7.0.5` has no matching RT patch yet; `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13 backport
 
@@ -61,8 +63,8 @@ Required checks before moving build defaults or release tags:
 The `6.12.87` tarball contains the `CVE-2026-43284` ESP shared-frag hardening,
 but the `rxkad.c` tree does not contain the reserved-`CVE-2026-43500` Dirty
 Frag RxRPC linearize/COW hardening. Do not promote `6.12.87` as a linux-xr
-fallback until the zero-fuzz DSC carry conflict is fixed and an RPM proof
-succeeds with the RxRPC security route applied.
+fallback until a real RPM proof succeeds with the RxRPC security route and the
+systemd/Rocky firmware-loader helper guard intact.
 
 RT remains separate until a compatible RT patch is proven:
 

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -155,9 +155,16 @@ scripts/config --enable CONFIG_OSNOISE_TRACER
 scripts/config --enable CONFIG_TIMERLAT_TRACER
 scripts/config --enable CONFIG_TRACER_SNAPSHOT
 scripts/config --enable CONFIG_X86_MSR
-# DELL_RBU disabled: its Kconfig has `select FW_LOADER_USER_HELPER` which
-# breaks systemd 257 boot. Use F12 BIOS flash menu instead (just bios-prepare-usb).
+# DELL_RBU and 6.12-era LP55XX LED support select FW_LOADER_USER_HELPER,
+# which breaks the systemd 257 boot contract. Use F12 BIOS flash menu instead
+# of DELL_RBU; keep LP55XX out unless a lab host proves it is needed.
 scripts/config --disable CONFIG_DELL_RBU
+scripts/config --disable CONFIG_LEDS_LP55XX_COMMON
+scripts/config --disable CONFIG_LEDS_LP5521
+scripts/config --disable CONFIG_LEDS_LP5523
+scripts/config --disable CONFIG_LEDS_LP5562
+scripts/config --disable CONFIG_LEDS_LP5569
+scripts/config --disable CONFIG_LEDS_LP8501
 scripts/config --disable CONFIG_ITCO_WDT
 
 # BCI workload support (CPU isolation, high-res timers)
@@ -213,6 +220,13 @@ make olddefconfig
 # make olddefconfig can re-enable options via Kconfig dependencies.
 # Re-apply critical overrides and abort if they don't stick.
 echo "=== Post-olddefconfig: re-applying critical systemd 257 overrides ==="
+scripts/config --disable CONFIG_DELL_RBU
+scripts/config --disable CONFIG_LEDS_LP55XX_COMMON
+scripts/config --disable CONFIG_LEDS_LP5521
+scripts/config --disable CONFIG_LEDS_LP5523
+scripts/config --disable CONFIG_LEDS_LP5562
+scripts/config --disable CONFIG_LEDS_LP5569
+scripts/config --disable CONFIG_LEDS_LP8501
 scripts/config --disable CONFIG_FW_LOADER_USER_HELPER
 scripts/config --disable CONFIG_DEBUG_INFO_NONE
 scripts/config --disable CONFIG_DEBUG_INFO_REDUCED
@@ -248,6 +262,8 @@ check_config() {
     fi
 }
 check_config CONFIG_FW_LOADER_USER_HELPER n
+check_config CONFIG_DELL_RBU n
+check_config CONFIG_LEDS_LP55XX_COMMON n
 check_config CONFIG_DEBUG_INFO_BTF y
 check_config CONFIG_DEBUG_INFO_NONE n
 check_config CONFIG_DEBUG_INFO_REDUCED n


### PR DESCRIPTION
## Summary

- Disable the 6.12-era LP55XX LED driver family in the RPM config override path because `LEDS_LP55XX_COMMON` selects `FW_LOADER_USER_HELPER`.
- Reapply those disables after `olddefconfig` and validate `CONFIG_DELL_RBU=n`, `CONFIG_LEDS_LP55XX_COMMON=n`, and `CONFIG_FW_LOADER_USER_HELPER=n` before build.
- Update the source-sync runbook to record the current 6.12.87 fallback proof gate.

## Validation

- `bash -n xr/scripts/build-rpm.sh xr/scripts/check-kernel-carry.sh xr/scripts/generate-cadence-report.sh`
- `git diff --check`
- `nix flake check --system x86_64-linux`

## Notes

The replacement 6.12.87 proof after PR #63 showed that patch application is fixed. It then failed because 6.12 Kconfig re-enabled `CONFIG_FW_LOADER_USER_HELPER=y` through the LP55XX LED selector. This PR keeps the Rocky/systemd firmware-loader helper guard intact on the fallback lane.
