### PR TITLE
[codex] security: allow absent usercopy default symbol

### DIFF
--- a/xr/scripts/check-security-config.sh
+++ b/xr/scripts/check-security-config.sh
@@ -58,6 +58,21 @@ expect_value() {
     fi
 }
 
+expect_value_when_available() {
+    local key="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(config_line "${key}")"
+    if [[ -z "${actual}" ]]; then
+        echo "  OK: ${key} absent in this kernel Kconfig"
+    elif [[ "${actual}" == "${key}=${expected}" ]]; then
+        echo "  OK: ${key}=${expected}"
+    else
+        fail_key "${key}" "${expected} when available" "${actual}"
+    fi
+}
+
 expect_disabled_or_absent() {
     local key="$1"
     local actual
@@ -131,7 +146,7 @@ expect_value CONFIG_EVM y
 # General hardening options that should not regress in this kernel lane.
 expect_value CONFIG_BPF_UNPRIV_DEFAULT_OFF y
 expect_value CONFIG_HARDENED_USERCOPY y
-expect_value CONFIG_HARDENED_USERCOPY_DEFAULT_ON y
+expect_value_when_available CONFIG_HARDENED_USERCOPY_DEFAULT_ON y
 expect_value CONFIG_SLAB_FREELIST_HARDENED y
 expect_value CONFIG_STRICT_DEVMEM y
 expect_value CONFIG_LSM_MMAP_MIN_ADDR 65535

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -16,7 +16,8 @@ As of 2026-05-09:
   repo-managed reserved-`CVE-2026-43500` RxRPC build route. The zero-fuzz DSC
   carry conflict is fixed; the next proof gate is preserving the
   `CONFIG_FW_LOADER_USER_HELPER=n` systemd/Rocky boot contract on this older
-  Kconfig.
+  Kconfig while allowing hardening symbols that do not exist yet in `6.12.y` to
+  be absent rather than disabled.
 - RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
 - RT blockers: newest stable `v7.0.5` has no matching RT patch yet; `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13 backport
 


### PR DESCRIPTION
## Summary

- Make the reusable security config checker require `CONFIG_HARDENED_USERCOPY_DEFAULT_ON=y` only when that symbol exists in the target kernel Kconfig.
- Keep `CONFIG_HARDENED_USERCOPY=y` mandatory, so the 6.12 fallback lane still carries the hardening option available in that branch.
- Update the source-sync runbook with the current 6.12.87 proof nuance.

## Validation

- `bash -n xr/scripts/check-security-config.sh xr/scripts/build-rpm.sh xr/scripts/check-kernel-carry.sh xr/scripts/generate-cadence-report.sh`
- `bash xr/scripts/check-security-config.sh xr/config/base.config`
- `bash xr/scripts/check-security-config.sh /tmp/linux-xr-security-no-usercopy-default.config`
- `git diff --check`
- `nix flake check --system x86_64-linux`

## Notes

The 6.12.87 proof after PR #64 passed patching and the firmware-loader helper guard, then failed because `CONFIG_HARDENED_USERCOPY_DEFAULT_ON` is absent from 6.12 Kconfig. This keeps the checker strict on kernels that expose the symbol while accepting older kernels where `CONFIG_HARDENED_USERCOPY=y` is the available guard.
