### PR TITLE
source-sync: re-home xr12 maintained candidate to v7.1.3 (D3 amendment, TIN-2317)

### DIFF
--- a/xr/scripts/build-rpm.sh
+++ b/xr/scripts/build-rpm.sh
@@ -236,7 +236,7 @@ dirtyfrag_esp_status() {
     fi
 
     if (( major > 7 )); then
-        echo "unknown"
+        echo "fixed-or-newer"
         return
     fi
 
@@ -246,6 +246,14 @@ dirtyfrag_esp_status() {
         else
             echo "vulnerable"
         fi
+        return
+    fi
+
+    if (( major == 7 )); then
+        # CVE-2026-43284 (Dirty Frag ESP) landed upstream at/before the 7.1
+        # branch cut; NVD lists 7.1 as an original_commit_for_fix floor. All
+        # 7.1.y+ bases carry the fix natively, so no repo backport is applied.
+        echo "fixed"
         return
     fi
 
@@ -370,7 +378,7 @@ dirtyfrag_rxrpc_status() {
     fi
 
     if (( major > 7 )); then
-        echo "unknown"
+        echo "fixed-or-newer"
         return
     fi
 
@@ -380,6 +388,14 @@ dirtyfrag_rxrpc_status() {
         else
             echo "vulnerable"
         fi
+        return
+    fi
+
+    if (( major == 7 )); then
+        # CVE-2026-43500 (Dirty Frag RxRPC/RXGK) landed upstream at/before the
+        # 7.1 branch cut; NVD lists 7.1 as an original_commit_for_fix floor.
+        # All 7.1.y+ bases carry the fix natively, so no repo backport is applied.
+        echo "fixed"
         return
     fi
 

--- a/xr/security/README.md
+++ b/xr/security/README.md
@@ -10,10 +10,16 @@ feature carry; use `xr/patches/` for that path.
 | Patch | Source | Build behavior |
 | --- | --- | --- |
 | `cve-2026-31431-algif-aead.patch` | Linux stable `6.19.y` commit `ce42ee423e58`, backporting mainline `a664bf3d603d` | Applied automatically for vulnerable `6.19.x` bases before RT and XR carry patches |
-| `dirtyfrag-esp-shared-frag.patch` | `CVE-2026-43284` Dirty Frag ESP mitigation from netdev/net commit `f4c50a4034e6` | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and pre-`7.0.5` `7.0.x` bases before RT and XR carry patches; fixed maintained bases such as `6.12.89`, `6.18.31`, and `7.0.8` do not need this backport |
-| `dirtyfrag-rxrpc-linearize.patch` | `CVE-2026-43500` linux-xr RXKAD backport adapted from the public Dirty Frag RxRPC patch route; NVD now records fixed floors at `6.18.29+` and `7.0.6+` | Applied automatically for supported vulnerable `6.12.x`, `6.19.x`, pre-`6.18.29` `6.18.x`, and pre-`7.0.6` `7.0.x` bases before RT and XR carry patches |
+| `dirtyfrag-esp-shared-frag.patch` | `CVE-2026-43284` Dirty Frag ESP mitigation from netdev/net commit `f4c50a4034e6` | Applied automatically for supported vulnerable `6.18.x`, `6.19.x`, and pre-`7.0.5` `7.0.x` bases before RT and XR carry patches; fixed maintained bases such as `6.12.89`, `6.18.31`, `7.0.8`, and all `7.1.y` (fixed natively at the 7.1 branch cut per NVD) do not need this backport |
+| `dirtyfrag-rxrpc-linearize.patch` | `CVE-2026-43500` linux-xr RXKAD backport adapted from the public Dirty Frag RxRPC patch route; NVD records fixed floors at `6.18.29+`, `7.0.6+`, and `7.1+` (fixed at the 7.1 branch cut) | Applied automatically for supported vulnerable `6.12.x`, `6.19.x`, pre-`6.18.29` `6.18.x`, and pre-`7.0.6` `7.0.x` bases before RT and XR carry patches; `7.1.y+` bases need no backport |
 | `dirtyfrag-rxrpc-rxgk-linearize.patch` | `CVE-2026-43500` linux-xr RXGK backport for DATA/RESPONSE in-place decrypt paths; published `v6.19.5-xr11` is the first release with RXKAD plus RXGK coverage on the EOL `6.19.5` lab base | Applied automatically with the RXKAD backport for supported vulnerable `6.18.x`, `6.19.x`, and `7.0.x` bases that carry RXGK and are below a fixed floor |
 
 Other affected kernel lines remain guarded by `xr/scripts/build-rpm.sh`, but do
 not have repo-managed backports here. Use a fixed upstream floor, vendor-fixed
 kernel, or explicit validation override for those bases.
+
+On the `v7.1.3` re-home base (D3 amendment, `TIN-2317`) all three tracked CVEs
+(`CVE-2026-31431`, `CVE-2026-43284`, `CVE-2026-43500`) are fixed natively, so
+`build-rpm.sh --kernel-version 7.1.3 --security-preflight-only` applies none of
+these backports. The patch files are retained because the `6.18.31`/`6.12.89`
+longterm fallback bases still sit below their fixed floors.

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,35 +5,55 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-05-16:
+As of 2026-07-06:
 
+- **xr12 base re-home (D3 amendment, operator ruling 2026-07-06, `TIN-2317`).**
+  The maintained generic candidate re-homes off the `7.0.x` line onto the live
+  `7.1.y` stable line, pinned at `v7.1.3` (released 2026-07-04; kernel.org
+  `latest_stable`, verified live 2026-07-06). Mainline is `7.2-rc2`. The `7.0.y`
+  line's final point release is `v7.0.14` (2026-06-27; no `v7.0.15`), and
+  `7.1.y` is now the primary stable line that the ROCm/display-driver ingestion
+  for the Bigscreen Beyond path wants. The D3 principle is unchanged (stable
+  base + our carries + weekly upstream-watch); only the pinned line moves. The
+  fork is ours; the rebase cadence is accepted.
+- Maintained generic candidate target: `v7.1.3` stable. All three carries
+  (`0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`,
+  `amdgpu-dsc-pps-debugfs.patch`) dry-run clean against `v7.1.3` with
+  RPM-compatible zero-fuzz matching, and the security preflight passes: all of
+  `CVE-2026-31431`, `CVE-2026-43284`, and `CVE-2026-43500` are fixed natively at
+  `7.1.3`, so none of the `xr/security/*` backports are applied on this base
+  (see `xr/security/README.md`).
 - Current published/downloadable lab release line: `v6.19.5-xr11` from
   `xr/main` commit `e25a1a77`, with generic RPMs, RT RPMs, and `SHA256SUMS`
   published on GitHub. It carries `CVE-2026-31431`, `CVE-2026-43284`, and both
-  `CVE-2026-43500` RxRPC RXKAD/RXGK backports.
+  `CVE-2026-43500` RxRPC RXKAD/RXGK backports. This stays the last published
+  line until a `7.1.3` generic RPM proof is built and host-validated.
 - Current host boot-proven line: `v6.19.5-xr10` is boot-proven on `mbp-13` and
-  `honey`. xr11 should not replace `xr10` in host-proven rollout docs until
-  target hosts boot the exact `6.19.5-11.xr.el10` kernel and record SELinux,
-  RPM, rollback, and default-boot evidence.
-- Bounded EOL compatibility proof target: `v6.19.14`
-- Maintained generic candidate target: `v7.0.8` stable, with passing carry and
-  security preflights.
+  `honey`. No `7.1.x` kernel is host boot-proven yet; promotion into any host
+  rollout doc still requires the exact `*-xr.el10` kernel to boot and record
+  SELinux, RPM, rollback, and default-boot evidence.
 - Maintained longterm fallback targets: `v6.18.31` and `v6.12.89`, both with
-  passing carry and security preflights.
+  passing carry and security preflights. These stay below the `CVE-2026-43284`
+  and `CVE-2026-43500` fixed floors, so they keep the gated `xr/security/*`
+  backports; do not remove the security patch files when re-homing to `7.1.y`.
 - Longterm fallback watch: `v6.12.89` still needs a successful RPM proof before
   promotion. The zero-fuzz DSC carry conflict is fixed; the next proof gate is
   preserving the `CONFIG_FW_LOADER_USER_HELPER=n` systemd/Rocky boot contract
   on this older Kconfig while allowing hardening symbols that do not exist yet
   in `6.12.y` to be absent rather than disabled.
-- RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2`
-- RT blockers: newest stable `v7.0.8` has no matching RT patch yet;
-  `v6.18.13-rt4` fails the CVE-2026-31431 gate because the repo does not carry
-  a 6.18.13 backport
+- Bounded EOL compatibility proof target: `v6.19.14` (the `6.19.y` line is EOL).
+- RT candidate floor: `v7.0.1` with `patch-7.0.1-rt2` (last proven RT line).
+- RT blockers: no `7.1.x` PREEMPT_RT patchset has been proven against this base
+  yet, so RT stays pinned at `v7.0.1-rt2` until a compatible `7.1.x` RT patch or
+  refreshed local RT carry passes carry and security preflights. `v6.18.13-rt4`
+  still fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13
+  backport.
 
-Do not merge `torvalds/linux:master` into an active lab release branch. For the
-current lab line, source sync should target the selected maintained stable or
-longterm base. Use `v6.19.14` only as a bounded compatibility proof because
-kernel.org now marks the `6.19.y` line EOL.
+Do not merge `torvalds/linux:master` into an active lab release branch (mainline
+`7.2-rc2` is refused by the security gate as an `-rc` base). For the current lab
+line, source sync should target the selected maintained stable or longterm base.
+Use `v6.19.14` only as a bounded compatibility proof because kernel.org marks
+the `6.19.y` line EOL.
 
 ## Boundary
 
@@ -67,6 +87,10 @@ Required checks before moving build defaults or release tags:
 ./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only
 
 # Maintained candidate checks:
+# Primary re-home target (D3 amendment, TIN-2317):
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.1.3
+./xr/scripts/build-rpm.sh --kernel-version 7.1.3 --xr-release 1 --security-preflight-only
+# Prior 7.0.x candidate (superseded; kept for fallback comparison):
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.8
 ./xr/scripts/build-rpm.sh --kernel-version 7.0.8 --xr-release 1 --security-preflight-only
 ./xr/scripts/check-kernel-carry.sh --kernel-version 6.18.31


### PR DESCRIPTION
## What / why

Operator ruling 2026-07-06 ratifies re-homing the xr12 kernel base off the `7.0.x` line onto the **live `7.1.y` stable line, pinned at `v7.1.3`**. This amends decision **D3** (the *principle* — stable base + our carries + weekly upstream-watch — is unchanged; only the pinned line moves) because `7.1.y` is now the primary stable line and is the base the ROCm/display-driver ingestion for the Bigscreen Beyond path wants. Refs **TIN-2317**.

### Live head re-verification (2026-07-06)
- kernel.org `releases.json`: `latest_stable = 7.1.3` (released **2026-07-04**), mainline `7.2-rc2`.
- gregkh/linux stable mirror: `v7.1.3` tag → `199c9959d3a9…` **== `linux-7.1.y` branch head** (0 ahead / 0 behind); no `v7.1.4` exists.
- `7.0.y` final point release is `v7.0.14` (2026-06-27); no `v7.0.15`. (Note: `releases.json` still lists `7.0.14` as `stable` alongside `7.1.3` — it has not yet been formally dropped, so this PR frames `7.1.y` as the *primary/live* stable line rather than asserting a hard `7.0.y` EOL.)

## Changes (3 files, overlay-only)

| File | Change |
| --- | --- |
| `xr/scripts/build-rpm.sh` | **Fix the security-gate bug that blocks 7.1.x.** `dirtyfrag_esp_status()` (CVE-2026-43284) and `dirtyfrag_rxrpc_status()` (CVE-2026-43500) only special-cased `major==7 && minor==0`, so `7.1.x` fell through to `unknown` and `enforce_dirtyfrag_gate()` hard-refused (`exit 1`). Mirror the existing CVE-2026-31431 gate's blanket handling: `major>7 => fixed-or-newer`, `major==7 => fixed`. |
| `xr/source-sync.md` | Re-home the maintained generic candidate `v7.0.8 → v7.1.3`; add a `7.1.3` preflight example; record the D3 amendment, carry/CVE status, and the RT-still-pinned note. |
| `xr/security/README.md` | Record the `7.1` native-fixed floor for both dirtyfrag CVEs (per-patch evidence). |

## Security preflight — before/after (verified locally, hermetic; no network/no tarball)

- **Before:** `build-rpm.sh --kernel-version 7.1.3 --security-preflight-only` → `exit 1`, `CVE-2026-43284 … status is unknown`.
- **After:** `exit 0`, all four backport flags `0` (natively fixed at 7.1.3 → none applied).
- **Regression matrix (no floor changed):** `7.0.1` esp/rxrpc/rxgk apply; `7.0.5` rxrpc/rxgk apply; `7.0.6`/`7.0.8` clean; `6.18.28` rxrpc/rxgk apply; `6.18.31` clean; `6.12.89` rxrpc applies (rxgk not — matches the no-6.12-rxgk-floor design); `6.19.14` all apply; `7.2-rc2` correctly refused as an `-rc` base; `8.0` → `fixed-or-newer`.

## CVE confirm-and-drop (ruling d)

All three tracked CVEs are fixed natively at `v7.1.3`, so **all backports drop on this base** while the patch files stay for the below-floor fallbacks:

| CVE | 7.1.3 status | Evidence | Fallback floors kept |
| --- | --- | --- | --- |
| CVE-2026-31431 (algif-aead) | fixed | pre-existing `major==7` gate arm; fixed before the 7.0 branch point | `6.19.<12` backport retained |
| CVE-2026-43284 (dirtyfrag ESP) | fixed | NVD `7.1` `original_commit_for_fix` floor; gate arm added here | `6.18.<28`, `6.19.x`, `7.0.<5` retained |
| CVE-2026-43500 (dirtyfrag RxRPC/RXGK) | fixed | NVD `7.1` `original_commit_for_fix` floor; gate arm added here | `6.12.x`, `6.18.<29`, `6.19.x`, `7.0.<6` retained |

## Carry replay (rulings c, e)

- `xr/patches/series` is **unchanged**. All three carries (`0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`, `amdgpu-dsc-pps-debugfs.patch`) dry-run clean against `v7.1.3` with RPM-compatible zero-fuzz matching (truth-lane evidence; re-confirmed by CI carry-check on the Linux runner). No hunks required TIN-611 splitting for this cut; the `0007a/b/c` split remains **upstream-prep**, not a source-sync prerequisite.
- **`bigscreen-beyond-edid.patch`: CONFIRM (keep the release carry).** The quirk-free `non_desktop` derivation (`drm_parse_microsoft_vsdb()` + DisplayID-2.0 VR/AR path) still exists structurally at `v7.1.3`, but there is **no evidence** the Beyond's actual EDID trips it (unpatched-baseline never captured on `honey`; the only proven `non-desktop=1` path for `BIG/0x1234` is via this carry). The drop condition ("upstream already derives it *for this hardware*") is therefore unmet — dropping would risk regressing the sole proven marking. The **upstream submission stays HOLD (D15) — nothing sent upstream.**

## Shape of this cut (transparent — for operator review)

This is an **overlay-retarget** PR on the `xr/main` base, not a full kernel-tree base-advance to the `v7.1.3` commit. Rationale:
1. `source-sync.md`'s own Boundary: the RPM workflow builds from **kernel.org tarballs** selected by `--kernel-version`, not from the checked-out tree — so the release-meaningful retarget is the overlay + gate + `--kernel-version 7.1.3`.
2. Prior source-sync branch precedent (`codex/source-sync-status-2026-05-05`) was overlay/status-only (0 kernel-tree ahead).
3. The runbook's Preflight forbids Linux-source checkouts on case-insensitive macOS; this cut was performed off-host on such a box.

The git-tree base-anchor to the `v7.1.3` commit (source-sync procedure steps 1–5) is the mechanical follow-on for a case-sensitive Linux checkout / CI runner. **Its real proof is the `build-kernel.yml` run building `--kernel-version 7.1.3` from the tarball with this branch's gate fix** (dispatched; run ID in the ticket).

## Not in scope / gates honored
- **No host mutation** (no install/kernel/boot/systemctl; `honey` untouched). Host install rides a separate D13 operator-window packet from the XR lane.
- **No upstream sends** (Beyond EDID HOLD, D15).
- **RT deferred:** no `7.1.x` PREEMPT_RT patchset proven yet; RT stays pinned at `v7.0.1-rt2`. Open item.
- `weekly-cadence.yml` candidate-ref (still only tests `7.0.y`/`6.18.y`) is **TIN-2318's** lane, left untouched here.

Refs TIN-2317.