### PR TITLE
fix(carry): refresh amdgpu DSC PPS debugfs carry to v7.1.3 context (TIN-611)

### DIFF
--- a/xr/patches/amdgpu-dsc-pps-debugfs.patch
+++ b/xr/patches/amdgpu-dsc-pps-debugfs.patch
@@ -18,10 +18,9 @@ Signed-off-by: Jess Sullivan <jess@jesssullivan.dev>
  1 file changed, 61 insertions(+)
 
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
-index 000000000000..111111111111 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c
-@@ -2268,6 +2268,66 @@ static ssize_t dp_dsc_bits_per_pixel_write(struct file *f, const char __user *bu
+@@ -2271,6 +2271,66 @@ done:
  	return size;
  }
  
@@ -88,7 +87,7 @@ index 000000000000..111111111111 100644
  /* function: read DSC picture width parameter on the connector
   *
   * The read function: dp_dsc_pic_width_read
-@@ -3107,6 +3167,7 @@ static const struct {
+@@ -3112,6 +3172,7 @@ static const struct {
  		{"dsc_slice_width", &dp_dsc_slice_width_debugfs_fops},
  		{"dsc_slice_height", &dp_dsc_slice_height_debugfs_fops},
  		{"dsc_bits_per_pixel", &dp_dsc_bits_per_pixel_debugfs_fops},


### PR DESCRIPTION
## What

Regenerate the `amdgpu-dsc-pps-debugfs` carry with fresh line context against
the re-homed **v7.1.3** candidate base, fixing the TIN-611 blocker.

## Why

`amdgpu-dsc-pps-debugfs.patch` applied clean under `git apply --check` (the
authoritative `git-tree-anchor` job) but **failed the rpmbuild `%prep`
patch-path** (`patch -p1 --fuzz=0`) at v7.1.3 — both hunks rejected
(`Hunk #1 FAILED at 2268`, `Hunk #2 FAILED at 3167`, "2 out of 2 hunks FAILED",
matching the fire-72 finding). The hunk context was stamped against the prior
7.0.x base; after the 7.0.y → 7.1.y re-home (TIN-2317) the touched file shifted,
so `patch --fuzz=0` (rpmbuild's applier) could not place the hunks. This is the
exact failure the non-blocking `rpm-carry-dryrun` advisory job tracks.

## Change

Diff regenerated against the live `v7.1.3` stable-tag copy of
`drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_debugfs.c`:

- hunk 1: `2268` → `2271` — new `dp_dsc_pic_parameter_set_read` + fops still
  inserted after `dp_dsc_bits_per_pixel_write`'s closing brace, before the
  `dp_dsc_pic_width_read` comment block
- hunk 2: `3107/3167` → `3112/3172` — debugfs table entry still placed between
  `dsc_bits_per_pixel` and `dsc_pic_width`
- drop the placeholder `index 00..11` line

**Semantics unchanged** — observability-only carry exposing the AMD DC cached
packed DSC PPS via read-only connector debugfs. The 61 inserted lines are
byte-identical to the prior revision; only hunk headers/context moved.

## Verification (local, against a v7.1.3 fixture of all touched carry files)

| Check | Before | After |
| --- | --- | --- |
| `git apply --check -p1` (anchor-job mirror) | clean | clean |
| `patch -p1 --fuzz=0` (rpmbuild `%prep` mirror, GNU patch 2.8), cumulative in series order | **amdgpu FAILS 2/2 hunks** | **clean, full series** |
| `check-rpm-patch-wiring.sh` | `amdgpu → Patch20` | `amdgpu → Patch20` |

Full series verified in order: `0007-vesa-dsc-bpp` → `bigscreen-beyond-edid` →
`amdgpu-dsc-pps-debugfs`. The other two carries still apply cleanly after this
one (both methods).

Closes the carry-refresh half of **TIN-611**; unblocks the `base-anchor`
`rpm-carry-dryrun` advisory job. `[cordillera-2026-07-09]`
