### PR TITLE
xr: stop shipping an XFS test-harness kernel

### DIFF
--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -190,10 +190,14 @@ scripts/config --disable CONFIG_ITCO_WDT
 #
 # It is not inert. Upstream fs/xfs/Kconfig on XFS_DEBUG: "the resulting code
 # will be HUGE and SLOW ... Say N unless you are an XFS developer, or you play
-# one on TV." The companion XFS_WARN entry states the distinction plainly --
-# WARN "is much lighter weight than XFS_DEBUG and does not modify algorithms
-# and will not cause the kernel to panic on non-fatal errors", i.e. XFS_DEBUG
-# does both. Concretely, XFS_DEBUG activates
+# one on TV." Dave Chinner is blunter in 742ae1e35b03 ("xfs: introduce
+# CONFIG_XFS_WARN", 2013-04-30), the commit that exists because of exactly this
+# mistake: "Running a CONFIG_XFS_DEBUG kernel in production environments is not
+# the best idea as it introduces significant overhead, can change the behaviour
+# of algorithms (such as allocation) to improve test coverage, and (most
+# importantly) panic the machine on non-fatal errors."
+#
+# Concretely, XFS_DEBUG activates
 # `do_sparse = get_random_u32_below(2)` in xfs_ialloc_ag_alloc(), forcing
 # sparse-inode allocation on a coin flip for test coverage, and
 # XFS_ASSERT_FATAL turns a non-fatal ASSERT into a filesystem shutdown.

--- a/xr/specs/kernel-xr.spec
+++ b/xr/specs/kernel-xr.spec
@@ -182,6 +182,38 @@ scripts/config --disable CONFIG_LEDS_LP5569
 scripts/config --disable CONFIG_LEDS_LP8501
 scripts/config --disable CONFIG_ITCO_WDT
 
+# XFS must not ship as a filesystem test harness on production hosts.
+# base.config inherits CONFIG_XFS_DEBUG=y + CONFIG_XFS_ASSERT_FATAL=y from the
+# scraped vendor config (base.config:10218,10220). That is accidental: this
+# kernel exists for VR display work and none of the carry patches in
+# xr/patches/series touch filesystem code.
+#
+# It is not inert. Upstream fs/xfs/Kconfig on XFS_DEBUG: "the resulting code
+# will be HUGE and SLOW ... Say N unless you are an XFS developer, or you play
+# one on TV." The companion XFS_WARN entry states the distinction plainly --
+# WARN "is much lighter weight than XFS_DEBUG and does not modify algorithms
+# and will not cause the kernel to panic on non-fatal errors", i.e. XFS_DEBUG
+# does both. Concretely, XFS_DEBUG activates
+# `do_sparse = get_random_u32_below(2)` in xfs_ialloc_ag_alloc(), forcing
+# sparse-inode allocation on a coin flip for test coverage, and
+# XFS_ASSERT_FATAL turns a non-fatal ASSERT into a filesystem shutdown.
+#
+# 2026-08-22 incident: honey's data-containers volume (/var/lib/rancher) shut
+# down on an invalid sparse inode record; xfs_inobt_insert_sprec() is in the
+# trace. honey went NotReady ~65 minutes with 81 pods stranded. sting carries
+# the identical config. bumble runs the stock Rocky kernel with both off and
+# has never entered that path.
+#
+# XFS_WARN is deliberately left off too: it is the lighter diagnostic
+# alternative, but nothing here is debugging an XFS problem. Turn it on only
+# for a specific investigation.
+#
+# Live oracle: /sys/fs/xfs/debug/ exists only under CONFIG_XFS_DEBUG=y. It must
+# be absent on every host running this kernel.
+scripts/config --disable CONFIG_XFS_DEBUG
+scripts/config --disable CONFIG_XFS_DEBUG_EXPENSIVE
+scripts/config --disable CONFIG_XFS_ASSERT_FATAL
+
 # BCI workload support (CPU isolation, high-res timers)
 scripts/config --enable CONFIG_CPU_ISOLATION
 scripts/config --enable CONFIG_NO_HZ_FULL
@@ -246,6 +278,9 @@ scripts/config --disable CONFIG_FW_LOADER_USER_HELPER
 scripts/config --disable CONFIG_DEBUG_INFO_NONE
 scripts/config --disable CONFIG_DEBUG_INFO_REDUCED
 scripts/config --enable CONFIG_DEBUG_INFO_BTF
+scripts/config --disable CONFIG_XFS_DEBUG
+scripts/config --disable CONFIG_XFS_DEBUG_EXPENSIVE
+scripts/config --disable CONFIG_XFS_ASSERT_FATAL
 
 # Run olddefconfig again to resolve any new dependencies from re-applied overrides
 make olddefconfig
@@ -284,6 +319,13 @@ check_config CONFIG_DEBUG_INFO_NONE n
 check_config CONFIG_DEBUG_INFO_REDUCED n
 check_config CONFIG_BPF_SYSCALL y
 check_config CONFIG_CGROUP_BPF y
+# Fleet contract: never ship an XFS test-harness build. See the override block
+# above and the 2026-08-22 honey filesystem shutdown. XFS_ASSERT_FATAL depends
+# on XFS_DEBUG, so it goes absent rather than =n once XFS_DEBUG is off; both
+# forms pass here.
+check_config CONFIG_XFS_DEBUG n
+check_config CONFIG_XFS_DEBUG_EXPENSIVE n
+check_config CONFIG_XFS_ASSERT_FATAL n
 %if "%{rt_version}" != ""
 check_config CONFIG_EXPERT y
 check_config CONFIG_PREEMPT_RT y
@@ -292,7 +334,8 @@ check_config CONFIG_PREEMPT_VOLUNTARY n
 %endif
 if [ "$fail" -ne 0 ]; then
     echo "FATAL: Critical kernel config validation failed. Aborting build."
-    echo "This kernel would fail to boot on systemd 257 (Rocky 10.1)."
+    echo "See the FAIL lines above: this kernel would either fail to boot on"
+    echo "systemd 257 (Rocky 10.1) or ship a config the fleet contract forbids."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

honey's and sting's XR kernels are built as XFS test harnesses. This turns that
off in the spec's explicit override block. **Rollout is not part of this PR** —
see the ceremony section below.

## Root cause

`xr/config/base.config` carries:

```
10218:CONFIG_XFS_DEBUG=y
10219:# CONFIG_XFS_DEBUG_EXPENSIVE is not set
10220:CONFIG_XFS_ASSERT_FATAL=y
```

Neither flag is inert:

- `CONFIG_XFS_DEBUG` activates `do_sparse = get_random_u32_below(2)` in
  `xfs_ialloc_ag_alloc()`. XFS *deliberately forces sparse-inode allocation on a
  coin flip* to get test coverage of that path.
- `CONFIG_XFS_ASSERT_FATAL` (`default y`, `depends on XFS_FS && XFS_DEBUG`)
  converts a non-fatal `ASSERT` failure into a `BUG()` / filesystem shutdown.

Upstream `fs/xfs/Kconfig` is explicit about the cost. On `XFS_DEBUG`:

> Note that the resulting code will be HUGE and SLOW, and probably not useful
> unless you are debugging a particular problem.
>
> Say N unless you are an XFS developer, or you play one on TV.

Dave Chinner is blunter. `742ae1e35b03` ("xfs: introduce CONFIG_XFS_WARN",
2013-04-30) — the commit that exists *because* people were doing what we are
doing — opens:

> Running a CONFIG_XFS_DEBUG kernel in production environments is not the best
> idea as it introduces significant overhead, **can change the behaviour of
> algorithms (such as allocation) to improve test coverage**, and (most
> importantly) **panic the machine on non-fatal errors.**

The `XFS_WARN` option it introduced is the supported way to keep ASSERT
visibility without any of that; its Kconfig entry says WARN "is much lighter
weight than XFS_DEBUG and does not modify algorithms and will not cause the
kernel to panic on non-fatal errors."

All three quotes verified verbatim in this tree: `fs/xfs/Kconfig` lines 194-243
at HEAD, and `git show 742ae1e35b038ed65ddd86182723441ea74db765`.

### The incident

2026-08-22, 17:09 EDT: honey's thin-LVM XFS volume `data-containers`
(`/var/lib/rancher`, the containerd store) detected an invalid sparse-inode
record and shut itself down. `xfs_inobt_insert_sprec()` is in the trace — that
is the `do_sparse` path. honey went NotReady for ~65 minutes with 81 pods
stranded, including the live mail stack. Repaired with `xfs_repair -L`; etcd
held 2/3 quorum throughout.

`bumble` runs the stock Rocky kernel with both flags off and has never entered
that path.

### The flag is accidental

- This kernel exists for VR display work (Bigscreen Beyond 2e / AMD DSC).
- All three carry patches in `xr/patches/series` touch display code only:
  `0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`,
  `amdgpu-dsc-pps-debugfs.patch`.
- `grep -rn -il xfs xr/ site/` returns exactly one file: `xr/config/base.config`.
  Nothing in this repo ever asked for a debug XFS.
- `git log -- xr/config/base.config` has a **single** commit: `ec426e5276707`
  (#4), a squashed bootstrap import. The file's own header records its origin as
  `6.19.5-1.el10.elrepo.x86_64`. The flag was inherited, never decided.

## Live oracle (pre-change, verified today)

`/sys/fs/xfs/debug/` exists **only** under `CONFIG_XFS_DEBUG=y`.

| host | `uname -r` | `ls /sys/fs/xfs/debug/` | `bug_on_assert` |
|---|---|---|---|
| honey | `6.19.5-11.xr.el10` | present (`always_cow bload_leaf_slack bload_node_slack bug_on_assert larp`) | `1` |
| sting | `6.19.5-9.xr.el10` | present (same set) | `1` |
| bumble | `6.12.0-211.37.1.el10_2.x86_64` (stock) | `No such file or directory` | n/a |

`grep -E '^CONFIG_XFS_(DEBUG|ASSERT_FATAL)=' /boot/config-$(uname -r)` returns
`=y` for both on honey and sting.

## The change

`xr/specs/kernel-xr.spec` only. `xr/config/base.config` is deliberately **not**
hand-edited — it is a scraped artifact.

```
scripts/config --disable CONFIG_XFS_DEBUG
scripts/config --disable CONFIG_XFS_DEBUG_EXPENSIVE
scripts/config --disable CONFIG_XFS_ASSERT_FATAL
```

placed in the explicit override block (the same block that already overrides HZ,
`DRM_AMD_DC_DSC`, USB, the SMI tracers, `X86_MSR`, and `DELL_RBU`/LP55XX), with
the justification comment alongside the neighbouring ones.

`XFS_DEBUG_EXPENSIVE` is already off and depends on `XFS_DEBUG`; it is listed
for completeness, matching how the `LEDS_LP55XX` family is handled two stanzas
above.

`XFS_WARN` is deliberately **not** enabled. It is the lighter alternative, but
nothing here is debugging an XFS problem; it should be turned on only for a
specific investigation.

## Anti-re-scrape: no new mechanism, three layers the spec already has

`xr/scripts/build-rpm.sh:676-682` is where the loop lives — when
`xr/config/base.config` is missing the script tells the operator to re-scrape it
off a running host:

```
echo "Extract from honey: ssh jess@honey 'cat /boot/config-\$(uname -r)' > xr/config/base.config"
```

which reads the debug flags back out of the very kernel that has them. Rather
than pinning the base config (which would freeze every unrelated vendor option
and fight the documented refresh path), this uses the override machinery that
already exists, in all three places it already exists:

1. **Overrides run after the scrape.** `%prep` does `cp %{SOURCE1} .config`
   (spec:153) and *then* applies `scripts/config` overrides. The override wins
   over whatever `base.config` contains, by construction, on every rebuild.
2. **Re-applied post-`olddefconfig`.** `make olddefconfig` can re-enable options
   through Kconfig dependencies, which is why the spec already has a
   "re-applying critical overrides" block. The three disables are added there,
   exactly as `DELL_RBU` and `DEBUG_INFO_BTF` are.
3. **Hard-failed at build time.** `check_config` — the spec's existing
   config-assertion test — gains:

   ```
   check_config CONFIG_XFS_DEBUG n
   check_config CONFIG_XFS_DEBUG_EXPENSIVE n
   check_config CONFIG_XFS_ASSERT_FATAL n
   ```

   A rebuild that somehow reinherits the flag aborts instead of shipping.

**Layer 3 is an extension of the existing test, not new machinery.**
`check_config` (spec:256-278) is the only config-assertion harness in the repo
that runs against the *resolved* `.config`; `xr/scripts/check-security-config.sh`
is scoped to SELinux/hardening posture and defaults to asserting against
`base.config` (the scraped input), so pinning there would assert against the
wrong artifact. No new test file, no new script.

`CONFIG_XFS_ASSERT_FATAL` depends on `XFS_DEBUG`, so once `XFS_DEBUG` is off the
symbol goes *absent* rather than `=n`. `check_config` already treats absent as a
pass for `expected=n` (spec:264-265).

### Proof the new assertion can fail

The estate's most common defect class is an assertion that cannot fail, so the
`check_config` function was extracted and run against both states:

```
--- CASE A: today's base.config state (must FAIL) ---
  FAIL: CONFIG_XFS_DEBUG should be disabled but got: CONFIG_XFS_DEBUG=y
  OK: CONFIG_XFS_DEBUG_EXPENSIVE is not set
  FAIL: CONFIG_XFS_ASSERT_FATAL should be disabled but got: CONFIG_XFS_ASSERT_FATAL=y
fail=1 (expect 1)
--- CASE B: post-fix expected state (must PASS) ---
  OK: CONFIG_XFS_DEBUG is not set
  OK: CONFIG_XFS_DEBUG_EXPENSIVE is absent
  OK: CONFIG_XFS_ASSERT_FATAL is absent
fail=0 (expect 0)
```

`%prep`'s shell body also passes `bash -n` after macro stripping. No `%`
characters were introduced (rpm expands macros inside `%prep` comments).

One adjacent one-line fix: the fatal message under `check_config` said only
"This kernel would fail to boot on systemd 257", which would now be a false
signal for an XFS failure. It names both classes.

## CI note

`RPM carry dry-run (advisory — tracks TIN-611)` failed on the first run at
`curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR` — 30M into
the 151M kernel tarball download, before the job ever reached the spec. Network
flake, not this change; re-run requested. Everything else (determinate-ci,
CodeQL, git-tree anchor, RPM security preflight) is green.

## Rollout is a SEPARATE attended per-node ceremony — NOT part of this PR

Merging this changes nothing on any host. honey and sting keep running their
current XFS-debug kernels until an operator performs the ceremony below. honey
is currently healthy (14% used, 650G free); there is no emergency.

1. **Build** the RPMs from `xr/main` after this merges (tag `v*-xr*` or
   `workflow_dispatch` on `.github/workflows/build-kernel.yml`). Confirm the
   build log shows `OK: CONFIG_XFS_DEBUG is not set`. Bump `xr_release`.
2. **honey first.** Install the RPM alongside the running kernel; do not remove
   the current `6.19.5-11.xr.el10` — the repo's rollback convention keeps prior
   generic kernels installed (`site/docs/honey.md`).
3. **Drain and reboot honey** into the new kernel, one node only.
4. **Verify on honey before touching sting:**
   - `ls /sys/fs/xfs/debug/` → `No such file or directory` (the pass condition)
   - `grep -E '^CONFIG_XFS_(DEBUG|ASSERT_FATAL)=' /boot/config-$(uname -r)` → no
     match
   - `uname -r` shows the new release
   - display/DSC still works (this kernel's actual purpose)
5. **Verify etcd quorum is restored to 3/3** before proceeding —
   `kubectl get nodes` all Ready, and etcd member health on all three voters.
   honey/bumble/sting are a 3-node stacked-etcd quorum; a second reboot before
   the first member is back is a quorum loss.
6. **Repeat 2-5 on sting.** bumble is stock and needs nothing.
7. **Final oracle:** `ls /sys/fs/xfs/debug/` returns `No such file or directory`
   on honey, sting, and bumble alike.

Rollback at any step is a reboot into the retained prior kernel.

## Scope

Out of scope, deliberately: migrating `data-containers` off XFS, or any
filesystem change. This removes the mechanism; a filesystem migration on a live
etcd voter is not justified by this evidence.

The other two independent root causes of the same incident (baseline CI writing
to the container writable layer on `data-containers`, and thin-pool trim merged
but never armed) are separate workstreams in the blahaj repo.
