### PR TITLE
docs(carry): verify all three carries clean at v7.1.12; retire the stale refresh claim (TIN-611, TIN-4065)

### DIFF
--- a/.github/workflows/base-anchor.yml
+++ b/.github/workflows/base-anchor.yml
@@ -8,8 +8,17 @@ name: Base Anchor (maintained candidate)
 #   git-tree-anchor          (deliverable a) — AUTHORITATIVE zero-fuzz carry
 #                            proof: checks out the upstream stable tag
 #                            case-sensitive, verifies the Makefile triplet, and
-#                            applies every xr/patches carry with git apply
+#                            checks every xr/patches carry with git apply
 #                            --check (strict, no fuzz) against the real tree.
+#                            KNOWN LIMITATION — the SAME one documented in
+#                            xr/scripts/check-kernel-carry.sh: --check never
+#                            writes, so each carry is checked INDEPENDENTLY
+#                            against the pristine tag tree, not against the tree
+#                            as modified by earlier entries in series order.
+#                            This job is authoritative for "does each carry
+#                            apply zero-fuzz to the stock tag." It does NOT
+#                            model rpmbuild's cumulative %prep, and no job in
+#                            this file does.
 #   rpm-security-preflight   (deliverable c) — build-rpm.sh --security-preflight-only:
 #                            the version-based CVE floor gate at the candidate
 #                            base (no -rc, CVE floors satisfied). Self-contained;
@@ -28,7 +37,11 @@ name: Base Anchor (maintained candidate)
 #                            #85 regenerated amdgpu-dsc-pps-debugfs.patch off
 #                            7.0.x context onto v7.1.3. All three carries now
 #                            apply with zero rejects and zero fuzz at v7.1.12,
-#                            cumulatively, in real %prep order. Do not re-derive
+#                            cumulatively, in real %prep order — but that
+#                            CUMULATIVE result is a LOCAL REPRODUCTION recorded
+#                            in xr/source-sync.md, not a product of any job in
+#                            this file. Both jobs here are pristine-per-patch.
+#                            Do not re-derive
 #                            "the carries are broken" from this comment block.
 #                            What TIN-611 still owes is the 0007a/0007b/0007c
 #                            SPLIT of the combined DSC carry — a code-reduction
@@ -154,7 +167,10 @@ jobs:
     name: RPM carry dry-run (advisory — tracks TIN-611)
     runs-on: ubuntu-latest
     # Advisory only: git-tree-anchor (git apply --check) is authoritative for
-    # carry application. This job mirrors rpmbuild %prep (patch-based).
+    # carry application. This job mirrors rpmbuild %prep (patch-based) in its
+    # per-patch invocation, but NOT in ordering: like git-tree-anchor, it checks
+    # each carry against a pristine tree, so neither job in this file models
+    # cumulative %prep. The cumulative result lives in xr/source-sync.md.
     # As of 2026-08-29 it is GREEN at the candidate base; it is kept
     # non-blocking so an upstream point release that shifts context is reported
     # rather than wedging the anchor lane. Lifting continue-on-error is a
@@ -186,4 +202,8 @@ jobs:
           echo "and a carry needs a line-context refresh before an RPM builds."
           echo "Note: this script dry-runs each carry independently against a"
           echo "pristine tree, so it does not model cumulative %prep ordering."
+          echo "Neither does git-tree-anchor: git apply --check never writes,"
+          echo "so it too checks each carry against the pristine tag tree. The"
+          echo "cumulative %prep proof is the local reproduction recorded in"
+          echo "xr/source-sync.md, not any job in this workflow."
           bash xr/scripts/check-kernel-carry.sh --kernel-version "${{ steps.v.outputs.kver }}"

--- a/.github/workflows/base-anchor.yml
+++ b/.github/workflows/base-anchor.yml
@@ -16,16 +16,30 @@ name: Base Anchor (maintained candidate)
 #                            exits before any tarball/carry staging.
 #   rpm-carry-dryrun         (advisory, non-blocking) — mirrors rpmbuild's
 #                            patch-based %prep (check-kernel-carry.sh). A failure
-#                            here means a carry needs a line-context refresh
-#                            before a 7.1.x RPM can build (carry-rebase lane
-#                            TIN-611 / NEW-1), which is PARKED out of this anchor
-#                            lane. git-tree-anchor above is authoritative for
-#                            "does the carry apply to the source."
+#                            here would mean a carry needs a line-context refresh
+#                            before a 7.1.x RPM can build. git-tree-anchor above
+#                            is authoritative for "does the carry apply to the
+#                            source."
+#
+#                            STATUS 2026-08-29 (TIN-611 / TIN-4065): this job is
+#                            GREEN and the carries need no refresh. The older
+#                            comment here asserted the opposite as a standing
+#                            fact; that was true only until 2026-07-09, when PR
+#                            #85 regenerated amdgpu-dsc-pps-debugfs.patch off
+#                            7.0.x context onto v7.1.3. All three carries now
+#                            apply with zero rejects and zero fuzz at v7.1.12,
+#                            cumulatively, in real %prep order. Do not re-derive
+#                            "the carries are broken" from this comment block.
+#                            What TIN-611 still owes is the 0007a/0007b/0007c
+#                            SPLIT of the combined DSC carry — a code-reduction
+#                            goal that does not block an RPM. See
+#                            xr/patches/0007-vesa-dsc-bpp.map.md.
 #
 # Context: executes the linux-xr 7.0.y -> 7.1.y re-home (D3 amendment, operator
 # ruling 2026-07-06, TIN-2317). Default candidate is the live 7.1.y stable head
-# v7.1.3 (re-verified live against kernel.org releases.json 2026-07-08 — still
-# the 7.1.y head, no v7.1.4; the 7.0.y line is EOL at v7.0.14). Override via the
+# v7.1.12 (released 2026-08-28; verified live against kernel.org releases.json
+# 2026-08-29, iseol: false). This advances the pin from v7.1.3, which was nine
+# point releases stale. The 7.0.y line is EOL at v7.0.14. Override via the
 # workflow_dispatch input when the maintained candidate moves.
 #
 # Runner: ubuntu-latest (GitHub-hosted) — the lightweight public-source anchor +
@@ -44,13 +58,15 @@ on:
       kernel_version:
         description: 'Maintained candidate kernel version (no leading v)'
         required: true
-        default: '7.1.3'
+        default: '7.1.12'
 
 permissions:
   contents: read
 
 env:
-  CANDIDATE_KVER: '7.1.3'
+  # Current 7.1.y stable head (2026-08-28). Advanced from 7.1.3 on 2026-08-29
+  # after re-verifying every carry at this base — see xr/source-sync.md.
+  CANDIDATE_KVER: '7.1.12'
 
 jobs:
   git-tree-anchor:
@@ -138,9 +154,11 @@ jobs:
     name: RPM carry dry-run (advisory — tracks TIN-611)
     runs-on: ubuntu-latest
     # Advisory only: git-tree-anchor (git apply --check) is authoritative for
-    # carry application. This job mirrors rpmbuild %prep (patch-based) and will
-    # go green when the carry-refresh (TIN-611 / NEW-1) lands. Non-blocking
-    # because carry-rebase onto 7.1.y is parked out of this anchor lane.
+    # carry application. This job mirrors rpmbuild %prep (patch-based).
+    # As of 2026-08-29 it is GREEN at the candidate base; it is kept
+    # non-blocking so an upstream point release that shifts context is reported
+    # rather than wedging the anchor lane. Lifting continue-on-error is a
+    # separate, deliberate gating decision.
     continue-on-error: true
     steps:
       - name: Resolve candidate version
@@ -163,7 +181,9 @@ jobs:
         run: |
           echo "Advisory: the authoritative zero-fuzz carry proof is the"
           echo "git-tree-anchor job (git apply --check). This mirrors rpmbuild"
-          echo "%prep (patch-based); a failure means a carry needs a line-context"
-          echo "refresh before a 7.1.x RPM can build — carry-rebase lane TIN-611"
-          echo "/ prompt-72 NEW-1, parked out of the F72 anchor lane."
+          echo "%prep (patch-based). Expected state as of 2026-08-29: PASS."
+          echo "A failure here means an upstream point release shifted context"
+          echo "and a carry needs a line-context refresh before an RPM builds."
+          echo "Note: this script dry-runs each carry independently against a"
+          echo "pristine tree, so it does not model cumulative %prep ordering."
           bash xr/scripts/check-kernel-carry.sh --kernel-version "${{ steps.v.outputs.kver }}"

--- a/xr/patches/0007-vesa-dsc-bpp.map.md
+++ b/xr/patches/0007-vesa-dsc-bpp.map.md
@@ -44,7 +44,26 @@ Observed on 2026-05-09:
   for `6.12.87`, `6.18.28`, `6.19.14`, and `7.0.5` before this carry can gate
   a source-sync or fallback release.
 
+Observed on 2026-08-29 (`TIN-611` / `TIN-4065`):
+
+- This carry applies to the maintained candidate base **`v7.1.12`** with zero
+  rejects and zero fuzz, both via `git apply --check -p1` and via
+  `patch -p1 --fuzz=0` (rpm's `%patch` default), including a cumulative
+  replication of the real `%prep` ordering against a sha256-verified
+  `linux-7.1.12.tar.xz`. Every moved hunk moved by pure line offset
+  (`amdgpu_dm.c` +127; `drm_edid.c` +32 and +73; `drm_connector.h` +2);
+  `qp_tables.h`, `rc_calc_fpu.c`, `drm_displayid_internal.h`, and
+  `drm_modes.h` matched at their recorded lines. **No context refresh was
+  needed and none was made.** The compatibility list above predates the
+  `7.0.y` -> `7.1.y` re-home; `7.1.12` is now the primary proven base.
+
 ## Split Plan
+
+**Status: NOT STARTED as of 2026-08-29.** This is `TIN-611`'s actual acceptance
+criteria and it is a code-reduction / upstream-trackability goal. It does
+**not** block an RPM build — the combined carry applies cleanly at `v7.1.12`
+(see above). Do not conflate "the carries need a context refresh" (retired,
+false since 2026-07-09) with "the carry has not been split" (true, below).
 
 1. Split parser and DRM propagation into `0007a-vesa-displayid-dsc-bpp-parser.patch`.
 2. Split AMDGPU fixed-BPP use into `0007b-amdgpu-use-fixed-dsc-bpp.patch`.

--- a/xr/scripts/check-kernel-carry.sh
+++ b/xr/scripts/check-kernel-carry.sh
@@ -22,6 +22,11 @@ Downloads a kernel.org tarball, optionally dry-runs the matching PREEMPT_RT
 patch first, then dry-runs every patch listed in xr/patches/series with
 RPM-compatible zero-fuzz matching.
 
+Zero-fuzz applies to the xr/patches carries only. The optional --rt-version
+dry-run deliberately runs bare `patch -p1` at patch(1)'s default fuzz, because
+that is how kernel-xr.spec applies the PREEMPT_RT patchset; it is not, and is
+not meant to be, a zero-fuzz check.
+
 Examples:
   ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14
   ./xr/scripts/check-kernel-carry.sh --kernel-version 6.19.14 --rt-version 6.19.3-rt1

--- a/xr/scripts/check-kernel-carry.sh
+++ b/xr/scripts/check-kernel-carry.sh
@@ -131,6 +131,14 @@ if [[ -n "${RT_VERSION}" ]]; then
 fi
 
 echo ">>> Dry-running linux-xr carry patches against ${KERNEL_VERSION}"
+# KNOWN LIMITATION (documented 2026-08-29, TIN-611 / TIN-4065): --dry-run never
+# writes, so each carry below is checked against the PRISTINE extraction rather
+# than against the tree as modified by the earlier entries in series order.
+# rpmbuild's %prep applies them cumulatively. Today the two agree, because
+# 0007-vesa-dsc-bpp.patch and bigscreen-beyond-edid.patch touch non-overlapping
+# line ranges of drm_edid.c and nothing else in series overlaps. A future carry
+# that lands in the same region as an earlier one would pass here and still
+# fail in %prep. Verify cumulatively before adding one.
 while IFS= read -r patch_file; do
     case "${patch_file}" in
         ""|\#*)

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -5,29 +5,79 @@ upstream stable target. It is separate from the RPM proof-build path.
 
 ## Current target
 
-As of 2026-07-06:
+As of 2026-08-29 (pin moved from `v7.1.3`; ruling record below unchanged):
 
 - **xr12 base re-home (D3 amendment, operator ruling 2026-07-06, `TIN-2317`).**
   The maintained generic candidate re-homes off the `7.0.x` line onto the live
-  `7.1.y` stable line, pinned at `v7.1.3` (released 2026-07-04; kernel.org
-  `latest_stable`, verified live 2026-07-06). Mainline is `7.2-rc2`. The `7.0.y`
-  line's final point release is `v7.0.14` (2026-06-27; no `v7.0.15`), and
-  `7.1.y` is now the primary stable line that the ROCm/display-driver ingestion
-  for the Bigscreen Beyond path wants. The D3 principle is unchanged (stable
-  base + our carries + weekly upstream-watch); only the pinned line moves. The
-  fork is ours; the rebase cadence is accepted.
-- Maintained generic candidate target: `v7.1.3` stable. All three carries
-  (`0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`,
-  `amdgpu-dsc-pps-debugfs.patch`) dry-run clean against `v7.1.3` with
-  RPM-compatible zero-fuzz matching, and the security preflight passes: all of
-  `CVE-2026-31431`, `CVE-2026-43284`, and `CVE-2026-43500` are fixed natively at
-  `7.1.3`, so none of the `xr/security/*` backports are applied on this base
-  (see `xr/security/README.md`).
+  `7.1.y` stable line. When the ruling was taken, the `7.1.y` head was `v7.1.3`
+  (released 2026-07-04) and mainline was `7.2-rc2`. The `7.0.y` line's final
+  point release is `v7.0.14` (2026-06-27; no `v7.0.15`), and `7.1.y` is the
+  primary stable line that the ROCm/display-driver ingestion for the Bigscreen
+  Beyond path wants. The D3 principle is unchanged (stable base + our carries +
+  weekly upstream-watch); only the pinned line moves. The fork is ours; the
+  rebase cadence is accepted.
+- **Maintained generic candidate target: `v7.1.12` stable** (released
+  2026-08-28; current `7.1.y` head per kernel.org `releases.json`, `iseol:
+  false`, verified live 2026-08-29). This advances the pin from `v7.1.3`, which
+  was nine point releases stale. Tarball
+  `linux-7.1.12.tar.xz` sha256
+  `389716b3ed27e4cd520b903eea04acc33b9804c4282cb7a918f05ff14e9b5ae1`, matched
+  against kernel.org `sha256sums.asc`; `Makefile` triplet confirmed
+  `VERSION=7 PATCHLEVEL=1 SUBLEVEL=12`.
+- **Carry verification at `v7.1.12` (2026-08-29, `TIN-611` / `TIN-4065`).** All
+  three carries (`0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`,
+  `amdgpu-dsc-pps-debugfs.patch`) apply with **zero rejects and zero fuzz**
+  against `v7.1.12`, under every path that matters:
+  - `git apply --check -p1`, cumulative in `series` order — clean (this is the
+    `base-anchor.yml` `git-tree-anchor` authoritative proof);
+  - `patch --batch -p1 --fuzz=0 --dry-run` against a pristine tree, per patch —
+    clean (this is the `check-kernel-carry.sh` / `rpm-carry-dryrun` path);
+  - **cumulative `%prep` replication** in real spec order and with each patch's
+    real invocation (`%patch -P0` → `--fuzz=0`, then the raw
+    `patch -p1 --fuzz=3` for `bigscreen-beyond-edid.patch`, then `%patch -P20`
+    → `--fuzz=0`) — clean. `rpm`'s `%_default_patch_fuzz` is `0` and
+    `%__scm_apply_patch` embeds `--fuzz=%{_default_patch_fuzz}` (verified in
+    `rpm-software-management/rpm` `macros.in`, branches `rpm-4.19.x`,
+    `rpm-4.20.x`, `master`), so `%patch -PN -p1` *is* the zero-fuzz path on the
+    `rockylinux/rockylinux:10` build image.
+  - A stricter-than-spec variant (cumulative, `--fuzz=0` for **all three**,
+    including `bigscreen-beyond-edid.patch`) is also clean, so the spec's
+    `--fuzz=3` override for that one patch is currently unnecessary headroom
+    rather than a load-bearing crutch.
+
+  Every hunk that moved did so by **pure line offset** (amdgpu_dm.c +127,
+  drm_edid.c +32/+73, drm_connector.h +2, drm_edid.c +25/+26 for the bigscreen
+  quirk); `amdgpu_dm_debugfs.c` needed no offset at all. Offset is not fuzz —
+  context matched exactly in every case. **No carry needed a line-context
+  refresh and none was made.**
+- **The "carries need a line-context refresh before a 7.1.x RPM builds" claim
+  is retired.** It was true before 2026-07-09, when
+  `amdgpu-dsc-pps-debugfs.patch` was still stamped against `7.0.x` context; PR
+  #85 regenerated it against `v7.1.3` and closed that half of `TIN-611`. The
+  claim survived only as prose in `base-anchor.yml` and in ticket summaries.
+  The advisory `rpm-carry-dryrun` job has in fact been **green** on `xr/main`
+  (run `33237032107`, 2026-08-29).
+- Security preflight at this base: `CVE-2026-31431`, `CVE-2026-43284`, and
+  `CVE-2026-43500` are all fixed natively at `7.1.12` — the `build-rpm.sh`
+  version gates return `fixed` and every `*_repo_backport_applies` helper
+  returns false, so **none** of the `xr/security/*` backports are applied on a
+  `7.1.x` base (see `xr/security/README.md`). Retiring those files is a
+  separate reviewed change and is **not** done here: the `6.18.x` / `6.12.x`
+  longterm fallbacks still select them.
 - Current published/downloadable lab release line: `v6.19.5-xr11` from
   `xr/main` commit `e25a1a77`, with generic RPMs, RT RPMs, and `SHA256SUMS`
   published on GitHub. It carries `CVE-2026-31431`, `CVE-2026-43284`, and both
   `CVE-2026-43500` RxRPC RXKAD/RXGK backports. This stays the last published
-  line until a `7.1.3` generic RPM proof is built and host-validated.
+  line until a `7.1.12` generic RPM proof is built and host-validated.
+- **Known remaining risk for a green `7.1.12` RPM (not a carry problem).**
+  `xr/config/base.config` is a scraped ElRepo **6.19.5** config (its own header
+  says `Linux/x86_64 6.19.5-1.el10.elrepo.x86_64`). `%prep` copies it to
+  `.config`, applies the XR overrides, runs `make olddefconfig` twice, and then
+  gates on `bash %{SOURCE2} .config` (`check-security-config.sh`). Kconfig
+  symbols renamed, removed, or newly dependency-gated between `6.19.y` and
+  `7.1.y` would surface there, not in the carries. That step has never been
+  exercised on a `7.1.x` tree. Likewise, the carries are proven to *apply* at
+  `7.1.12` but have never been *compiled* on a `7.1.x` base.
 - Current host boot-proven line: `v6.19.5-xr10` is boot-proven on `mbp-13` and
   `honey`. No `7.1.x` kernel is host boot-proven yet; promotion into any host
   rollout doc still requires the exact `*-xr.el10` kernel to boot and record
@@ -49,8 +99,10 @@ As of 2026-07-06:
   still fails the CVE-2026-31431 gate because the repo does not carry a 6.18.13
   backport.
 
-Do not merge `torvalds/linux:master` into an active lab release branch (mainline
-`7.2-rc2` is refused by the security gate as an `-rc` base). For the current lab
+Do not merge `torvalds/linux:master` into an active lab release branch. Mainline
+is `7.2` (released 2026-08-16, current stable head `v7.2.2`); any `-rc` base is
+refused outright by the security gate, and a just-cut `7.2.y` line is not a
+maintained candidate here. For the current lab
 line, source sync should target the selected maintained stable or longterm base.
 Use `v6.19.14` only as a bounded compatibility proof because kernel.org marks
 the `6.19.y` line EOL.
@@ -87,9 +139,12 @@ Required checks before moving build defaults or release tags:
 ./xr/scripts/build-rpm.sh --kernel-version 6.19.14 --xr-release 1 --security-preflight-only
 
 # Maintained candidate checks:
-# Primary re-home target (D3 amendment, TIN-2317):
+# Primary re-home target (D3 amendment, TIN-2317), pinned at the current
+# 7.1.y head as of 2026-08-29:
+./xr/scripts/check-kernel-carry.sh --kernel-version 7.1.12
+./xr/scripts/build-rpm.sh --kernel-version 7.1.12 --xr-release 1 --security-preflight-only
+# Prior 7.1.x pin (superseded 2026-08-29; kept for comparison):
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.1.3
-./xr/scripts/build-rpm.sh --kernel-version 7.1.3 --xr-release 1 --security-preflight-only
 # Prior 7.0.x candidate (superseded; kept for fallback comparison):
 ./xr/scripts/check-kernel-carry.sh --kernel-version 7.0.8
 ./xr/scripts/build-rpm.sh --kernel-version 7.0.8 --xr-release 1 --security-preflight-only

--- a/xr/source-sync.md
+++ b/xr/source-sync.md
@@ -28,8 +28,14 @@ As of 2026-08-29 (pin moved from `v7.1.3`; ruling record below unchanged):
   three carries (`0007-vesa-dsc-bpp.patch`, `bigscreen-beyond-edid.patch`,
   `amdgpu-dsc-pps-debugfs.patch`) apply with **zero rejects and zero fuzz**
   against `v7.1.12`, under every path that matters:
-  - `git apply --check -p1`, cumulative in `series` order — clean (this is the
-    `base-anchor.yml` `git-tree-anchor` authoritative proof);
+  - `git apply --check -p1`, cumulative in `series` order — clean. This
+    cumulative run is the **local reproduction** recorded here. CI's
+    `base-anchor.yml` `git-tree-anchor` job runs the same
+    `git apply --check -p1`, but it checks each carry **independently against
+    the pristine `v7.1.12` tag tree** — `--check` never writes, so no earlier
+    carry is in the tree when the next one is checked. It is authoritative for
+    "does each carry apply zero-fuzz to the stock tag"; it is not a cumulative
+    proof, and no job in `base-anchor.yml` is;
   - `patch --batch -p1 --fuzz=0 --dry-run` against a pristine tree, per patch —
     clean (this is the `check-kernel-carry.sh` / `rpm-carry-dryrun` path);
   - **cumulative `%prep` replication** in real spec order and with each patch's
@@ -50,6 +56,22 @@ As of 2026-08-29 (pin moved from `v7.1.3`; ruling record below unchanged):
   quirk); `amdgpu_dm_debugfs.c` needed no offset at all. Offset is not fuzz —
   context matched exactly in every case. **No carry needed a line-context
   refresh and none was made.**
+
+  **Why the pristine-per-patch checks and the cumulative `%prep` run agree at
+  this base — derived, not asserted.** In `series` order the only
+  `0007-vesa-dsc-bpp.patch` hunk touching `drm_edid.c` *ahead of* the bigscreen
+  quirk is `@@ -45,6 +45,7 @@` — a net **+1** line at line 45; that carry's
+  next `drm_edid.c` hunk is way down at line 6566.
+  `bigscreen-beyond-edid.patch` targets lines **125** and **222** of the same
+  file, which sit strictly between those two points and share no context lines
+  with either, so applying `0007` first shifts bigscreen's targets by exactly
+  one line and disturbs nothing else: its pristine per-patch offsets of
+  **+24/+25** become exactly the **+25/+26** recorded above. The third carry,
+  `amdgpu-dsc-pps-debugfs.patch`, touches only `amdgpu_dm_debugfs.c`, which no
+  other carry in `series` touches at all. That arithmetic — not any property of
+  the checks themselves — is the entire reason a pristine-per-patch verdict and
+  a cumulative one coincide here. It is a fact about the current hunk layout and
+  must be re-derived whenever a carry is added, split, or moved.
 - **The "carries need a line-context refresh before a 7.1.x RPM builds" claim
   is retired.** It was true before 2026-07-09, when
   `amdgpu-dsc-pps-debugfs.patch` was still stamped against `7.0.x` context; PR


### PR DESCRIPTION
## What this is

**(A) The context refresh — this PR.** Re-verification of every `xr/patches`
carry against the current `7.1.y` head. **Result: no carry needed a refresh, and
no patch byte was changed.**

**(B) The `0007a`/`0007b`/`0007c` split — NOT in this PR.** That is TIN-611's
actual acceptance criteria. It is a code-reduction / upstream-trackability goal
and it **does not block an RPM build**. It remains outstanding. Conflating (A)
and (B) is why this ticket has sat since April.

Refs: **TIN-611**, **TIN-4065**.

## Option A ruling

Option A is the `7.1.x` base. The governing ruling is the **xr12 base re-home,
D3 amendment, operator ruling 2026-07-06 (TIN-2317)**: the maintained generic
candidate re-homes off `7.0.x` onto the live `7.1.y` stable line. That ruling
is unchanged here; only the pin inside the line moves.

## The stale pin

| | version | released | note |
|---|---|---|---|
| Old pin | **`v7.1.3`** | 2026-07-04 | what `source-sync.md`, `CANDIDATE_KVER`, and the dispatch default all said |
| Current head | **`v7.1.12`** | 2026-08-28 | current `7.1.y` head, `iseol: false`, per kernel.org `releases.json` verified live 2026-08-29 |

`v7.1.3` was **nine point releases stale**. (`7.0.y` is EOL at `v7.0.14`;
mainline is now `7.2`, current stable head `v7.2.2` — not a candidate here.)

## The claim this PR retires

TIN-4065 carried the lead that *"the advisory `rpm-carry-dryrun` job says the
carries need a line-context refresh before a 7.1.x RPM builds."*

**That is stale.** It was true until **2026-07-09**, when PR #85 regenerated
`amdgpu-dsc-pps-debugfs.patch` off `7.0.x` context onto `v7.1.3` and closed the
carry-refresh half of TIN-611. The claim survived only as prose — in
`base-anchor.yml`'s comment block and in its job's `echo` output — which this PR
corrects. Primary evidence that it is stale:

- `base-anchor.yml` run **`33237032107`** on `xr/main` (2026-08-29): all three
  jobs `success`, including `RPM carry dry-run (advisory — tracks TIN-611)`.
- Independent local reproduction at `v7.1.12`, below.

## Method

The strict path was verified from primary source, not assumed.
`%_default_patch_fuzz` is `0` and `%__scm_apply_patch` embeds
`--fuzz=%{_default_patch_fuzz}` in `rpm-software-management/rpm` `macros.in` on
branches `rpm-4.19.x`, `rpm-4.20.x`, and `master`. The build image is
`rockylinux/rockylinux:10`. So **`%patch -PN -p1` == `patch -p1 --fuzz=0`**.

Fixture is the real thing, not a per-file fetch: `linux-7.1.12.tar.xz` from
`cdn.kernel.org` — the exact artifact `build-rpm.sh` and `check-kernel-carry.sh`
download — sha256 `389716b3ed27e4cd520b903eea04acc33b9804c4282cb7a918f05ff14e9b5ae1`,
matched against kernel.org's published `sha256sums.asc`. `Makefile` triplet
confirmed `VERSION=7 PATCHLEVEL=1 SUBLEVEL=12` before any test. GNU patch 2.8.

`%prep` order and per-patch invocation were replicated exactly as the spec
writes them: `%patch -P0` → `--fuzz=0`, then the raw
`patch -p1 --fuzz=3 < bigscreen-beyond-edid.patch`, then `%patch -P20` →
`--fuzz=0`.

## Per-patch apply matrix — v7.1.12

BEFORE = `xr/main` @ `3af8709`. AFTER = this PR. **They are identical, because
no patch file was touched.** Both columns are shown because the task was to
prove the refresh, and the honest proof is that none was required.

| Patch | `git apply --check -p1` (cumulative) | strict `patch -p1 --fuzz=0` (cumulative, real `%prep`) | rejects | fuzz used |
|---|---|---|---|---|
| `0007-vesa-dsc-bpp.patch` | BEFORE clean / AFTER clean | BEFORE clean / AFTER clean | 0 | 0 |
| `bigscreen-beyond-edid.patch` | BEFORE clean / AFTER clean | BEFORE clean / AFTER clean | 0 | 0 |
| `amdgpu-dsc-pps-debugfs.patch` | BEFORE clean / AFTER clean | BEFORE clean / AFTER clean | 0 | 0 |

Four paths were run, all `rc=0`, all zero rejects:

- **A** — `check-kernel-carry.sh` / `rpm-carry-dryrun` path:
  `patch --batch -p1 --fuzz=0 --dry-run` per patch against a pristine tree.
- **B** — `rpmbuild %prep` path: cumulative, real per-patch invocations
  (`--fuzz=0`, `--fuzz=3`, `--fuzz=0`). **This is the one that gates the RPM.**
- **C** — stricter than the spec: cumulative, `--fuzz=0` for **all three**,
  including `bigscreen-beyond-edid.patch`. Also clean — so the spec's
  `--fuzz=3` override on that patch is currently unused headroom, not a
  load-bearing crutch.
- **D** — `git apply --check -p1`, cumulative, `series` order. **This is a
  local reproduction, not a CI result.** CI's `git-tree-anchor` job runs the
  same `git apply --check -p1`, but it checks each carry *independently against
  the pristine `v7.1.12` tag tree* — `--check` never writes, so no earlier carry
  is in the tree when the next is checked. That is pristine-per-patch, exactly
  the limitation this PR documents for `check-kernel-carry.sh`.
  `git-tree-anchor` is authoritative for "does each carry apply zero-fuzz to the
  stock tag"; **no job in `base-anchor.yml` applies the carries cumulatively.**
  B, C and D above are the only cumulative evidence and all three were run
  locally.

**Why pristine-per-patch and cumulative agree here (derived, not asserted).** In
`series` order the only `0007-vesa-dsc-bpp.patch` hunk touching `drm_edid.c`
ahead of the bigscreen quirk is `@@ -45,6 +45,7 @@` — net **+1** at line 45;
that carry's next `drm_edid.c` hunk is at line 6566.
`bigscreen-beyond-edid.patch` targets lines **125** and **222**, strictly
between those two and sharing no context with either, so its pristine offsets of
**+24/+25** become exactly the **+25/+26** in the table below.
`amdgpu-dsc-pps-debugfs.patch` touches only `amdgpu_dm_debugfs.c`, which no
other carry touches. The agreement is arithmetic about the current hunk layout,
not a property of the checks — re-derive it whenever a carry is added, split, or
moved. Recorded in `xr/source-sync.md`.

Every hunk that moved moved by **pure line offset**, never fuzz — context
matched exactly:

| File | Offset at v7.1.12 |
|---|---|
| `amdgpu_dm.c` | +127 (hunks 1–3) |
| `drm_edid.c` (DSC carry) | +32 (hunks 2–6), +73 (hunk 7) |
| `drm_connector.h` | +2 |
| `drm_edid.c` (bigscreen quirk, applied 2nd) | +25 / +26 |
| `qp_tables.h`, `rc_calc_fpu.c`, `drm_displayid_internal.h`, `drm_modes.h` | 0 |
| `amdgpu_dm_debugfs.c` | 0 |

Repo static guards: `check-rpm-patch-wiring.sh` → `rc=0` (all three wired);
`check-security-config.sh` on `base.config` → passes.

## Semantic stops

**None.** No hunk's target code had moved or changed in a way that required a
judgement call, so nothing was rewritten and there was nothing to smuggle. If a
future point release does shift real context, the right move is to stop on that
patch rather than re-derive its intent.

## `xr/security/*` — retires at this base, NOT deleted here

Exercising `build-rpm.sh`'s own gate functions at `7.1.12`:
`cve_2026_31431_status` → `fixed`, `dirtyfrag_esp_status` → `fixed`,
`dirtyfrag_rxrpc_status` → `fixed`, and **all four**
`*_repo_backport_applies` helpers return false. So none of
`cve-2026-31431-algif-aead.patch`, `dirtyfrag-esp-shared-frag.patch`,
`dirtyfrag-rxrpc-linearize.patch`, or `dirtyfrag-rxrpc-rxgk-linearize.patch` is
applied on a `7.1.x` base.

**Recorded as a follow-up; deliberately not deleted.** The `6.18.x` / `6.12.x`
longterm fallbacks still select them, and deletion is a separate reviewed
change.

## What still blocks a green RPM

None of these are carry problems.

1. **Kconfig resolution — the top risk.** `xr/config/base.config` is a scraped
   ElRepo **6.19.5** config (its own header says
   `Linux/x86_64 6.19.5-1.el10.elrepo.x86_64`, 11,630 lines). `%prep` copies it
   to `.config`, applies the XR overrides, runs `make olddefconfig` **twice**,
   then gates on `bash %{SOURCE2} .config` (`check-security-config.sh`, spec
   line 346). Symbols renamed, removed, or newly dependency-gated between
   `6.19.y` and `7.1.y` surface *there*. **This step has never been exercised on
   a `7.1.x` tree.** It cannot be proven without a real build.
2. **Never compiled on `7.1.x`.** The carries are proven to *apply* at
   `v7.1.12`; they have never been *compiled* against a `7.1.x` amdgpu.
3. **Dispatch input.** `build-kernel.yml`'s `kernel_version` default and the
   spec's own `%{!?kversion}` default are both still `6.19.5`. Left alone
   deliberately — #94 tuned those dispatch defaults on purpose, and
   `build-rpm.sh` passes `--define kversion`. **The dispatcher must type
   `7.1.12`.**
4. **RT must be skipped.** No `7.1.x` PREEMPT_RT patchset is proven; the RT
   matrix entry is pinned at `6.19.3-rt1`. Dispatch `variant: generic`.
5. **Not host boot-proven.** No `7.1.x` kernel is boot-proven on any lab host.

## Changes

- `xr/source-sync.md` — pin `v7.1.3` → `v7.1.12`; full verification record with
  date, tarball sha256, and Makefile triplet; the Kconfig risk called out; the
  `xr/security/*` retirement recorded as a follow-up; preflight commands moved
  to `7.1.12`; corrected a now-false line claiming mainline is `7.2-rc2`.
  Then (`cd6e494`) re-attributed the cumulative `git apply --check` run to the
  local reproduction and added the derivation of why pristine-per-patch and
  cumulative agree at this base.
- `.github/workflows/base-anchor.yml` — `CANDIDATE_KVER` and the dispatch
  default → `7.1.12`; rewrote the comment block and job `echo` that asserted the
  refresh-needed blocker as standing fact. `continue-on-error: true` is
  **unchanged** — lifting it is a separate gating decision. Then (`cd6e494`)
  extended the KNOWN-LIMITATION language to `git-tree-anchor` itself: it is
  `git apply --check`, which never writes, so it is pristine-per-patch too, and
  neither job in the file models cumulative `%prep`.
- `xr/patches/0007-vesa-dsc-bpp.map.md` — recorded the `v7.1.12` result;
  Split Plan explicitly marked **NOT STARTED** and explicitly non-blocking.
- `xr/scripts/check-kernel-carry.sh` — **comment only, behaviour unchanged.**
  Documents that its `--dry-run` loop checks each carry against the *pristine*
  extraction, so it does not model cumulative `%prep`. Today both agree
  (`0007` and `bigscreen` touch non-overlapping ranges of `drm_edid.c`), but a
  future carry landing in an earlier carry's region would pass here and still
  fail in `%prep`. `cd6e494` also corrected the usage text, which claimed
  zero-fuzz matching for everything it runs: the optional `--rt-version`
  dry-run is bare `patch -p1` at default fuzz **on purpose**, because that is
  how `kernel-xr.spec` applies the RT patchset. The command is unchanged.

**No `.patch` file is modified by this PR.**

## Follow-ups (not done here)

- Retire `xr/security/*` once the longterm fallbacks no longer select them.
- `triage-upstream-targets.sh` `STABLE_FAMILIES` is still `("7.0" "6.18" "6.12")`
  — no `7.1`, so the weekly cadence does not even watch the maintained line.
- `triage-upstream-targets.sh` `RT_FAMILIES` (line 15) is `("7.0" "6.18" "6.19")`
  — also no `7.1`, so the RT side of that cadence does not watch the maintained
  line either. The script is **not** changed by this PR; disclosed here only.
- Consider making `check-kernel-carry.sh` apply cumulatively so it truly mirrors
  `%prep`.
- Consider lifting `continue-on-error` on `rpm-carry-dryrun` now that it is
  green.
- **TIN-611's real remaining work: the `0007a`/`0007b`/`0007c` split.**

Not merged, and no build dispatched — both are the operator's ratified steps.

